### PR TITLE
Improved 'direct method' for converting contours to meshes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
              rsync -avP /out/ ./Windows/
              strip ./Windows/usr/bin/*exe
              strip ./Windows/usr/lib/*a
+             git config --global --add safe.directory '*' || true
       - name: test
         run: |
              export DEBIAN_FRONTEND='noninteractive'
@@ -47,7 +48,7 @@ jobs:
              ./integration_tests/Run.sh -v
       - name: create_zip
         run: |
-             export short_sha="$(git rev-parse --short HEAD)"
+             export short_sha="$(git rev-parse --short HEAD || printf 'unknown')"
              export DEBIAN_FRONTEND="noninteractive"
              apt-get update --yes
              apt-get install --yes --no-install-recommends coreutils binutils findutils rsync openssh-client patchelf zip
@@ -86,6 +87,7 @@ jobs:
         run: |
              ( ( while true ; do sleep 225 ; printf '\n\n' ; df -h ; printf '\n\n' ; free || true ; printf '\n\n' ; done ) &)
              ./docker/builders/ci/implementation_ci_debian_oldstable.sh
+             git config --global --add safe.directory '*' || true
       - name: test
         run: |
              ./integration_tests/Run.sh -v

--- a/compile_and_install.sh
+++ b/compile_and_install.sh
@@ -16,8 +16,8 @@ shopt -s nocasematch
 
 # The temporary location in which to build.
 #BUILDROOT="/home/hal/Builds/DICOMautomaton/"
-BUILDROOT="/tmp/dcma_build"
-#BUILDROOT="build"
+# BUILDROOT="/tmp/dcma_build"
+BUILDROOT="build"
 
 DISTRIBUTION="auto" # used to tailor the build process for specific distributions/environments.
 
@@ -190,6 +190,7 @@ elif [[ "${DISTRIBUTION}" =~ .*debian.* ]] ; then
           -DWITH_ASAN=OFF \
           -DWITH_TSAN=OFF \
           -DWITH_MSAN=OFF \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
           ../
     fi
     JOBS=$(nproc)

--- a/scripts/compare_all_meshes.sh
+++ b/scripts/compare_all_meshes.sh
@@ -61,7 +61,7 @@ do
   shape=${shapes[$i]}
   res=${resolutions[$i]}
   shape_label=${shape_labels[$i]}
-  # echo "Computing differences for $shape"
+
   OUTPUT="$(dicomautomaton_dispatcher \
     -v \
     -o GenerateMeshes \
@@ -126,8 +126,6 @@ do
 
   printf "| %-20s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f | %-10.3f | %-10.3f | %-10.3f | %-8s | %-8s |\n\n" $shape_label $HD1 $HD2 $SA1 $SA2 $SA_DIFF $V1 $V2 $V_DIFF $MA1 $MA2
 
-
-  # echo "Finished computing differences for $shape"
 done
 
 

--- a/scripts/compare_all_meshes.sh
+++ b/scripts/compare_all_meshes.sh
@@ -54,7 +54,7 @@ declare -a shape_labels=("Sphere(10)" "aa_box(1.0,2.0,4.0)" "tri-force" "chamfer
 declare -a shapes=("Sphere(10)" "aa_box(1.0,2.0,4.0)" "$tri_force_shape" "chamfer_subtract(2.0){aa_box(8.0,20.0,20.0);sphere(12.0);}")
 declare -a resolutions=("$default_res" "0.25,0.25,0.75" "0.25,0.25,0.75" "$default_res")
 
-printf "| %-20s | %-13s | %-13s | %-15s | %-15s | %-10s | %-15s | %-15s | %-10s| \n\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Surface Area 2" "Area Diff" "Volume 1" "Volume 2" "Volume Diff"
+printf "| %-20s | %-13s | %-13s | %-15s | %-15s | %-10s | %-10s | %-10s | %-10s| %-8s | %-8s | \n\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Surface Area 2" "Area Diff" "Vol 1" "Vol 2" "Vol Diff" "Manifold 1" "Manifold 2"
 
 for i in ${!shapes[@]}
 do
@@ -106,7 +106,7 @@ do
   SA_DIFF_LINE=$(grep "SURFACE AREA (%) difference" <<< "$OUTPUT")
   VOL_LINE=$(grep "VOLUME: First mesh" <<< "$OUTPUT")
   VOL_DIFF_LINE=$(grep "VOLUME (%) difference" <<< "$OUTPUT")
-
+  MA_LINE=$(grep "MANIFOLD: First mesh" <<< "$OUTPUT")
 
   HD1=$(sed -r "s/.*([0-9]+\.[0-9]+) or.*/\1/g" <<< $HD_LINE)
   HD2=$(sed -r "s/.*or ([0-9]+\.[0-9]+).*/\1/g" <<< $HD_LINE)
@@ -121,10 +121,10 @@ do
 
   V_DIFF=$(sed -r "s/.*difference: (-?[0-9]+\.[0-9]+).*/\1/g" <<< $VOL_DIFF_LINE)
 
-  # echo "$HD1"
-  # echo "$HD2"
+  MA1=$(sed -r "s/.*First mesh = ([0-9]+).*/\1/g" <<< $MA_LINE)
+  MA2=$(sed -r "s/.*second mesh = ([0-9]+).*/\1/g" <<< $MA_LINE)
 
-  printf "| %-20s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f | %-15.3f | %-15.3f | %-10.3f |\n\n" $shape_label $HD1 $HD2 $SA1 $SA2 $SA_DIFF $V1 $V2 $V_DIFF
+  printf "| %-20s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f | %-10.3f | %-10.3f | %-10.3f | %-8s | %-8s |\n\n" $shape_label $HD1 $HD2 $SA1 $SA2 $SA_DIFF $V1 $V2 $V_DIFF $MA1 $MA2
 
 
   # echo "Finished computing differences for $shape"

--- a/scripts/compare_all_meshes.sh
+++ b/scripts/compare_all_meshes.sh
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 POSITIONAL_ARGS=()
 OPERATIONS=""
 VERBOSE=0
@@ -54,7 +54,8 @@ declare -a shape_labels=("Sphere(10)" "aa_box(1.0,2.0,4.0)" "tri-force" "chamfer
 declare -a shapes=("Sphere(10)" "aa_box(1.0,2.0,4.0)" "$tri_force_shape" "chamfer_subtract(2.0){aa_box(8.0,20.0,20.0);sphere(12.0);}")
 declare -a resolutions=("$default_res" "0.25,0.25,0.75" "0.25,0.25,0.75" "$default_res")
 
-printf "| %-20s | %-13s | %-13s | %-15s | %-15s | %-10s |\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Surface Area 2" "Area Diff"
+printf "| %-20s | %-13s | %-13s | %-15s | %-15s | %-10s | %-15s | %-15s | %-10s| \n\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Surface Area 2" "Area Diff" "Volume 1" "Volume 2" "Volume Diff"
+
 for i in ${!shapes[@]}
 do
   shape=${shapes[$i]}
@@ -102,7 +103,10 @@ do
   fi
   HD_LINE=$(grep "HAUSDORFF DISTANCE" <<< "$OUTPUT")
   SA_LINE=$(grep "SURFACE AREA: First mesh" <<< "$OUTPUT")
-  SA_DIFF_LINE=$(grep "SURFACE AREA difference" <<< "$OUTPUT")
+  SA_DIFF_LINE=$(grep "SURFACE AREA (%) difference" <<< "$OUTPUT")
+  VOL_LINE=$(grep "VOLUME: First mesh" <<< "$OUTPUT")
+  VOL_DIFF_LINE=$(grep "VOLUME (%) difference" <<< "$OUTPUT")
+
 
   HD1=$(sed -r "s/.*([0-9]+\.[0-9]+) or.*/\1/g" <<< $HD_LINE)
   HD2=$(sed -r "s/.*or ([0-9]+\.[0-9]+).*/\1/g" <<< $HD_LINE)
@@ -112,12 +116,16 @@ do
 
   SA_DIFF=$(sed -r "s/.*difference: (-?[0-9]+\.[0-9]+).*/\1/g" <<< $SA_DIFF_LINE)
 
+  V1=$(sed -r "s/.*First mesh = ([0-9]+\.[0-9]+).*/\1/g" <<< $VOL_LINE)
+  V2=$(sed -r "s/.*second mesh = ([0-9]+\.[0-9]+).*/\1/g" <<< $VOL_LINE)
+
+  V_DIFF=$(sed -r "s/.*difference: (-?[0-9]+\.[0-9]+).*/\1/g" <<< $VOL_DIFF_LINE)
+
   # echo "$HD1"
   # echo "$HD2"
-  # echo "$SA1"
-  # echo "$SA2"
-  # echo "$SA_DIFF"
-  printf "| %-20s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f |\n" $shape_label $HD1 $HD2 $SA1 $SA2 $SA_DIFF
+
+  printf "| %-20s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f | %-15.3f | %-15.3f | %-10.3f |\n\n" $shape_label $HD1 $HD2 $SA1 $SA2 $SA_DIFF $V1 $V2 $V_DIFF
+
 
   # echo "Finished computing differences for $shape"
 done

--- a/scripts/compare_all_meshes.sh
+++ b/scripts/compare_all_meshes.sh
@@ -24,18 +24,47 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+tri_force_shape="
+subtract(){
+  join(){
+    plane(0,0,0, 1,1,0, 10);
+    plane(0,0,0, 0,1,1, 10);
+    plane(0,0,0, 1,0,1, 10);
 
-declare -a shapes=("Sphere(10)" "Sphere(5)" "Sphere(7)")
-# declare -a shapes=("Sphere(10)" ")
+    plane(10,10,10, -1,-1,-0, 10);
+    plane(10,10,10, -0,-1,-1, 10);
+    plane(10,10,10, -1,-0,-1, 10);
+  };
 
-printf "| %-15s | %-13s | %-13s | %-15s | %-15s | %-10s |\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Aurface Area 2" "Area Diff"
-for shape in "${shapes[@]}"
+  join(){
+    plane(0,0,0, 1,2,0, 10);
+    plane(0,0,0, 0,1,2, 10);
+    plane(0,0,0, 2,0,1, 10);  
+
+    plane(10,10,10, -2,-1,-0, 10);
+    plane(10,10,10, -0,-2,-1, 10);
+    plane(10,10,10, -1,-0,-2, 10);
+  };
+};
+"
+
+default_res="0.25,0.25,0.25"
+
+declare -a shape_labels=("Sphere(10)" "aa_box(1.0,2.0,4.0)" "tri-force" "chamfered(box-sphere)")
+declare -a shapes=("Sphere(10)" "aa_box(1.0,2.0,4.0)" "$tri_force_shape" "chamfer_subtract(2.0){aa_box(8.0,20.0,20.0);sphere(12.0);}")
+declare -a resolutions=("$default_res" "0.25,0.25,0.75" "0.25,0.25,0.75" "$default_res")
+
+printf "| %-20s | %-13s | %-13s | %-15s | %-15s | %-10s |\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Surface Area 2" "Area Diff"
+for i in ${!shapes[@]}
 do
+  shape=${shapes[$i]}
+  res=${resolutions[$i]}
+  shape_label=${shape_labels[$i]}
   # echo "Computing differences for $shape"
   OUTPUT="$(dicomautomaton_dispatcher \
     -v \
     -o GenerateMeshes \
-      -p resolution="0.25, 0.25, 0.25" \
+      -p resolution=$res \
       -p MeshLabel="original" \
       -p Objects="$shape" \
     -o GenerateSyntheticImages \
@@ -88,7 +117,7 @@ do
   # echo "$SA1"
   # echo "$SA2"
   # echo "$SA_DIFF"
-  printf "| %-15s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f |\n" $shape $HD1 $HD2 $SA1 $SA2 $SA_DIFF
+  printf "| %-20s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f |\n" $shape_label $HD1 $HD2 $SA1 $SA2 $SA_DIFF
 
   # echo "Finished computing differences for $shape"
 done

--- a/scripts/compare_all_meshes.sh
+++ b/scripts/compare_all_meshes.sh
@@ -1,0 +1,103 @@
+
+POSITIONAL_ARGS=()
+OPERATIONS=""
+VERBOSE=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -s|--show)
+      OPERATIONS+="-o SDL_Viewer"
+      shift # past argument
+      ;;
+    -v|--verbose)
+      VERBOSE=1
+      shift # past argument
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+
+declare -a shapes=("Sphere(10)" "Sphere(5)" "Sphere(7)")
+# declare -a shapes=("Sphere(10)" ")
+
+printf "| %-15s | %-13s | %-13s | %-15s | %-15s | %-10s |\n" Shape "Hausdorff 1" "Hausdorff 2" "Surface Area 1" "Aurface Area 2" "Area Diff"
+for shape in "${shapes[@]}"
+do
+  # echo "Computing differences for $shape"
+  OUTPUT="$(dicomautomaton_dispatcher \
+    -v \
+    -o GenerateMeshes \
+      -p resolution="0.25, 0.25, 0.25" \
+      -p MeshLabel="original" \
+      -p Objects="$shape" \
+    -o GenerateSyntheticImages \
+      -p NumberOfImages='128' \
+      -p NumberOfRows='64', \
+      -p NumberOfColumns='64' \
+      -p NumberOfChannels='1' \
+      -p SliceThickness='1' \
+      -p SpacingBetweenSlices='1' \
+      -p VoxelWidth='1.0' \
+      -p VoxelHeight='1.0' \
+      -p ImageAnchor='-14.0, -14.0, -14.0' \
+      -p ImagePosition='0.0, 0.0, 0.0' \
+      -p ImageOrientationColumn='1.0, 0.0, 0.0' \
+      -p ImageOrientationRow='0.0, 1.0, 0.0' \
+      -p InstanceNumber='1' \
+      -p AcquisitionNumber='1' \
+      -p VoxelValue='0.0' \
+      -p StipleValue='nan' \
+    -o ConvertMeshesToContours \
+      -p ROILabel="original contours" \
+      -p MeshSelection="last" \
+      -p ImageSelection="last" \
+    -o ConvertContoursToMeshes \
+      -p NormalizedROILabelRegex=".*" \
+      -p ROILabelRegex=".*" \
+      -p MeshLabel="reconstructed" \
+      -p Method="direct" \
+    -o CompareMeshes \
+      -p MeshSelection1="#-0" \
+      -p MeshSelection2="#-1" \
+    $OPERATIONS 2>&1)"
+  if [ "$VERBOSE" == 1 ]; then
+    echo "$OUTPUT"
+  fi
+  HD_LINE=$(grep "HAUSDORFF DISTANCE" <<< "$OUTPUT")
+  SA_LINE=$(grep "SURFACE AREA: First mesh" <<< "$OUTPUT")
+  SA_DIFF_LINE=$(grep "SURFACE AREA difference" <<< "$OUTPUT")
+
+  HD1=$(sed -r "s/.*([0-9]+\.[0-9]+) or.*/\1/g" <<< $HD_LINE)
+  HD2=$(sed -r "s/.*or ([0-9]+\.[0-9]+).*/\1/g" <<< $HD_LINE)
+
+  SA1=$(sed -r "s/.*First mesh = ([0-9]+\.[0-9]+).*/\1/g" <<< $SA_LINE)
+  SA2=$(sed -r "s/.*second mesh = ([0-9]+\.[0-9]+).*/\1/g" <<< $SA_LINE)
+
+  SA_DIFF=$(sed -r "s/.*difference: (-?[0-9]+\.[0-9]+).*/\1/g" <<< $SA_DIFF_LINE)
+
+  # echo "$HD1"
+  # echo "$HD2"
+  # echo "$SA1"
+  # echo "$SA2"
+  # echo "$SA_DIFF"
+  printf "| %-15s | %-13.3f | %-13.3f | %-15.3f | %-15.3f | %-10.3f |\n" $shape $HD1 $HD2 $SA1 $SA2 $SA_DIFF
+
+  # echo "Finished computing differences for $shape"
+done
+
+
+
+
+
+
+
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,9 @@ set_target_properties(  Standard_Scripts_obj PROPERTIES POSITION_INDEPENDENT_COD
 add_library(            Surface_Meshes_obj OBJECT Surface_Meshes.cc )
 set_target_properties(  Surface_Meshes_obj PROPERTIES POSITION_INDEPENDENT_CODE TRUE )
 
+add_library(            Complex_Branching_Meshing_obj OBJECT Complex_Branching_Meshing.cc )
+set_target_properties(  Complex_Branching_Meshing_obj PROPERTIES POSITION_INDEPENDENT_CODE TRUE )
+
 add_library(            Simple_Meshing_obj OBJECT Simple_Meshing.cc )
 set_target_properties(  Simple_Meshing_obj PROPERTIES POSITION_INDEPENDENT_CODE TRUE )
 
@@ -368,6 +371,7 @@ add_executable (dicomautomaton_dispatcher
     $<TARGET_OBJECTS:Insert_Contours_obj>
     $<TARGET_OBJECTS:Surface_Meshes_obj>
     $<TARGET_OBJECTS:Simple_Meshing_obj>
+    $<TARGET_OBJECTS:Complex_Branching_Meshing_obj>
     $<TARGET_OBJECTS:Regex_Selectors_obj>
     $<TARGET_OBJECTS:String_Parsing_obj>
     $<TARGET_OBJECTS:Metadata_obj>
@@ -463,6 +467,7 @@ if(WITH_WT)
         $<TARGET_OBJECTS:Insert_Contours_obj>
         $<TARGET_OBJECTS:Surface_Meshes_obj>
         $<TARGET_OBJECTS:Simple_Meshing_obj>
+        $<TARGET_OBJECTS:Complex_Branching_Meshing_obj>
         $<TARGET_OBJECTS:Regex_Selectors_obj>
         $<TARGET_OBJECTS:String_Parsing_obj>
         $<TARGET_OBJECTS:Metadata_obj>

--- a/src/Complex_Branching_Meshing.cc
+++ b/src/Complex_Branching_Meshing.cc
@@ -1,0 +1,464 @@
+//Complex_Branching_Meshing.cc - A part of DICOMautomaton 2020. Written by hal clark.
+
+#include <string>
+#include <fstream>
+#include <vector>
+#include <set>
+#include <map>
+#include <unordered_map>
+#include <list>
+#include <stack>
+#include <functional>
+#include <numeric>
+#include <iterator>
+#include <thread>
+#include <array>
+#include <mutex>
+#include <limits>
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+
+#include <cstdlib> //Needed for exit() calls.
+#include <utility> //Needed for std::pair.
+#include <algorithm>
+#include <optional>
+
+#include "YgorMisc.h" //Needed for FUNCINFO, FUNCWARN, FUNCERR macros.
+#include "YgorLog.h"
+#include "YgorMath.h" //Needed for vec3 class.
+
+#include "Structs.h"
+
+#include "Complex_Branching_Meshing.h"
+
+// HELPERS
+
+// rotates a contour such that all the contour points lie in the XY plane
+// and the contour normal is parallel to the z-axis
+// modifies contour in place
+void
+Rotate_Contour_Onto_XY(contour_of_points<double> &cop, const vec3<double> &cont_normal) {
+    //The rotation matrix R that rotates the contour normal to the direction of
+    //the z-axis can be applied to all the contour points to move them to the XY plane
+    auto unitNormContour = cont_normal.unit();
+
+    vec3<double> unitNormDesired = vec3<double>(0, 0, 1);
+    if((unitNormDesired.Cross(unitNormContour)).length() == 0) {
+        return;
+    };
+
+    //obtaining R matrix as described here https://math.stackexchange.com/a/2672702
+    num_array<double> I = num_array<double>().identity(3);
+    auto k              = unitNormContour + unitNormDesired;
+    auto K              = k.to_num_array();
+    auto scale          = 2 / (K.transpose() * K).read_coeff(0, 0);
+    auto R              = K * K.transpose() *= (scale);
+    R                   = R - I;
+    //apply rotation to all points
+    for(auto &point : cop.points) {
+        point = (R * point.to_num_array()).to_vec3();
+    }
+}
+
+// retrieve element in stack underneath top element
+int
+Next_To_Top(std::stack<int> &s) {
+    auto p = s.top();
+    s.pop();
+    auto res = s.top();
+    s.push(p);
+    return res;
+}
+
+// returns 0 if collinear, 1 if CW, 2 if CCW
+// CW if looking from p, we go CW from q to r
+// CCW if looking from p, we go CCW from q to r
+int
+orientation(const vec3<double> p, const vec3<double> q, const vec3<double> r) {
+    auto val = (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+    if(val == 0)
+        return 0;
+    return (val > 0) ? 1 : 2;
+}
+
+// MAIN METHODS
+
+// returns contour of points of convex hull by following https://www.geeksforgeeks.org/convex-hull-using-graham-scan/
+contour_of_points<double>
+Contour_From_Convex_Hull_2(std::vector<contour_of_points<double>> &cops, const vec3<double> &cont_normal) {
+    if(cops.size() == 0) {
+        YLOGINFO("Returning empty contour of points.");
+        return contour_of_points<double>();
+    }
+
+    contour_of_points<double> merged_cop;
+
+    for(auto &cop : cops) {
+        merged_cop.points.insert(merged_cop.points.end(), cop.points.begin(), cop.points.end());
+    }
+
+    contour_of_points<double> rotated_cop(merged_cop);
+    Rotate_Contour_Onto_XY(rotated_cop, cont_normal);
+
+    // creating vector from list for quick access
+    std::vector<vec3<double>> points(rotated_cop.points.begin(), rotated_cop.points.end());
+
+    // create vector of associated indices to manipulate when finding convex hull
+    // useful for recreating contour of points for convex hull with same order as input
+    std::vector<int> indices(points.size());
+    std::iota(std::begin(indices), std::end(indices), 0);
+
+    // returns point based on index from indices[i]
+    const auto get_point = [&](int i) -> vec3<double> {
+        return points[indices[i]];
+    };
+
+    // find leftest and lowest point
+    double ymin = get_point(0).y;
+    int min_i   = 0;
+
+    for(int i = 1; i < indices.size(); ++i) {
+        int y = get_point(i).y;
+        if(y < ymin || (ymin == y && get_point(i).x < get_point(min_i).x)) {
+            ymin  = y;
+            min_i = i;
+        }
+    }
+    std::iter_swap(indices.begin() + 0, indices.begin() + min_i);
+
+    // sort rest of points to form a simple closed path CCW
+    const auto p0 = get_point(0);
+
+    // returns true if point A is closer to p0 than point B
+    const auto compare_points = [&](const int index_A, const int index_B) -> bool {
+        const auto point_A = points[index_A];
+        const auto point_B = points[index_B];
+        const int o        = orientation(p0, point_A, point_B);
+
+        if(o == 0)
+            return (point_B.sq_dist(p0) > point_A.sq_dist(p0)) ? true : false;
+
+        return (o == 2) ? true : false;
+    };
+
+    std::sort(indices.begin() + 1, indices.end(), [&](const int A, const int B) -> bool {
+        return compare_points(A, B);
+    });
+
+    int m = 1; // size of array for concave hull
+
+    // only keep furthest point if multiple points form the same angle with p0
+    for(int i = 1; i < points.size(); ++i) {
+        while(i < points.size() - 1 && orientation(p0, get_point(i), get_point(i + 1)) == 0) {
+            i++;
+        }
+
+        indices[m] = indices[i];
+        m++;
+    }
+
+    if(m < 3) {
+        throw std::runtime_error("Convex hull is not possible for less than 3 points");
+    }
+
+    // remove concave points
+    std::stack<int> s;
+    s.push(0);
+    s.push(1);
+    s.push(2);
+
+    for(int i = 3; i < m; ++i) {
+        while(s.size() > 1 && orientation(get_point(Next_To_Top(s)), get_point(s.top()), get_point(i)) != 2) {
+            s.pop();
+        }
+        s.push(i);
+    }
+
+    // stack contains output points
+    std::vector<int> kept_indices;
+    while(!s.empty()) {
+        kept_indices.emplace_back(indices[s.top()]);
+        s.pop();
+    }
+
+    contour_of_points<double> convex_hull_contour;
+
+    std::vector<vec3<double>> merged_points(merged_cop.points.begin(), merged_cop.points.end());
+
+    for(auto i : kept_indices) {
+        convex_hull_contour.points.emplace_back(merged_points[i]);
+    }
+
+    convex_hull_contour.closed = true;
+
+    return convex_hull_contour;
+}
+
+// assumes there are only two contours in cops
+// modifies convex hull by adding midpoints and including more original contour points
+// returns closed modified convex hull, two non-convex hull contours (one for each original contour), and list of midpoints
+// the non-convex hull contours start and end with closest point on convex hull
+std::tuple<contour_of_points<double>, contour_of_points<double>, contour_of_points<double>, std::vector<vec3<double>>>
+Modify_Convex_Hull(const contour_of_points<double> &convex_hull, const std::vector<contour_of_points<double>> cops,
+                   const vec3<double> &pseudo_vert_offset) {
+    vec3<double> start_A;
+    vec3<double> end_A;
+    vec3<double> start_B;
+    vec3<double> end_B;
+    vec3<double> midpoint_for_end_A;
+    vec3<double> midpoint_for_start_A;
+
+    bool found_first = false;
+
+    int prev_contour_index = -1;
+    vec3<double> prev_point;
+    int first_point_contour_index = 0;
+
+    for(auto it = convex_hull.points.begin(); it != convex_hull.points.end(); it++) {
+        int curr_contour_index = 0;
+        for(auto &cop : cops) {
+            if(std::find(cop.points.begin(), cop.points.end(), *it) != cop.points.end()) {
+                if(prev_contour_index != -1 && prev_contour_index != curr_contour_index) {
+                    vec3<double> midpoint = (*it + prev_point) / 2 + pseudo_vert_offset;
+                    if(!found_first) {
+                        end_A              = prev_point;
+                        start_B            = *it;
+                        midpoint_for_end_A = midpoint;
+                        found_first        = true;
+                    } else {
+                        end_B                = prev_point;
+                        start_A              = *it;
+                        midpoint_for_start_A = midpoint;
+                    }
+                }
+                break;
+            }
+            curr_contour_index += 1;
+        }
+        if(it == convex_hull.points.begin()) {
+            first_point_contour_index = curr_contour_index;
+        }
+        prev_contour_index = curr_contour_index;
+        prev_point         = *it;
+
+        // check last point and first point
+        if(it == std::prev(convex_hull.points.end()) && first_point_contour_index != curr_contour_index) {
+            end_B                 = *it;
+            start_A               = *(convex_hull.points.begin());
+            vec3<double> midpoint = (*it + *(convex_hull.points.begin())) / 2 + pseudo_vert_offset;
+            midpoint_for_start_A  = midpoint;
+            break;
+        }
+    }
+
+    // swap points depending on orientation
+    bool convex_hull_ccw = convex_hull.Is_Counter_Clockwise();
+    if(cops[first_point_contour_index].Is_Counter_Clockwise() != convex_hull_ccw) {
+        std::swap(start_A, end_A);
+        std::swap(midpoint_for_start_A, midpoint_for_end_A);
+    }
+    if(cops[1 - first_point_contour_index].Is_Counter_Clockwise() != convex_hull_ccw) {
+        std::swap(start_B, end_B);
+    }
+
+    auto d1 = start_A.sq_dist(midpoint_for_start_A);
+    auto d2 = end_A.sq_dist(midpoint_for_end_A);
+    if (std::max(d1,d2) > 2 * std::min(d1,d2)) throw std::runtime_error("Complex 2 to 1 meshing is not suitable for this contour. Aborted");
+
+    const auto get_convex_and_non_convex_points =
+        [&](const int contour_index, vec3<double> start_point,
+            vec3<double> end_point) -> std::tuple<std::list<vec3<double>>, std::list<vec3<double>>> {
+        std::list<vec3<double>> split_section_1;
+        std::list<vec3<double>> consecutive_section_2;
+        std::list<vec3<double>> split_section_3;
+
+        bool is_consecutive_section_convex_hull = false;
+        bool found_start_point                  = false;
+        bool found_end_point                    = false;
+        bool filling_split_section              = true;
+        bool on_split_section_3                 = false;
+
+        for(auto point : cops[contour_index].points) {
+            if(point == start_point) {
+                if(found_end_point) { // already found end point before, so doing 3rd portion
+                    on_split_section_3    = true;
+                    filling_split_section = true;
+                } else {
+                    filling_split_section = false;
+                }
+                found_start_point = true;
+            }
+
+            if(point == end_point) {
+                if(found_start_point) { // already found start point, so doing 3rd portion
+                    is_consecutive_section_convex_hull = true;
+                    filling_split_section              = true;
+                    on_split_section_3                 = true;
+                    consecutive_section_2.emplace_back(point); // don't want the end point to be in the third portion
+                } else {
+                    filling_split_section = false;
+                    split_section_1.emplace_back(point);
+                }
+                found_end_point = true;
+                continue; // since we placed the point in the previous section already
+            }
+
+            if(filling_split_section) {
+                if(on_split_section_3) {
+                    split_section_3.emplace_back(point);
+                } else {
+                    split_section_1.emplace_back(point);
+                }
+            } else {
+                consecutive_section_2.emplace_back(point);
+            }
+        }
+
+        split_section_3.insert(split_section_3.end(), split_section_1.begin(), split_section_1.end());
+
+        std::list<vec3<double>> &convex_hull_points = split_section_3;
+        std::list<vec3<double>> &other_points       = consecutive_section_2;
+
+        if(is_consecutive_section_convex_hull) {
+            std::swap(convex_hull_points, other_points);
+        }
+
+        // add start and end points to non convex hull points to ensure proper meshing
+        other_points.emplace_front(convex_hull_points.back());
+        other_points.emplace_back(convex_hull_points.front());
+
+        return std::make_tuple(convex_hull_points, other_points);
+    };
+
+    // create better convex hull by chaining original points
+    auto [convex_hull_A, other_A] = get_convex_and_non_convex_points(first_point_contour_index, start_A, end_A);
+    auto [convex_hull_B, other_B] = get_convex_and_non_convex_points(1 - first_point_contour_index, start_B, end_B);
+
+    // flip contour B if end point is closer to midpoint for end A
+    if(end_B.sq_dist(midpoint_for_end_A) < start_B.sq_dist(midpoint_for_end_A)) {
+        convex_hull_B.reverse();
+        other_B.reverse();
+    }
+
+    // add midpoints in contour
+    contour_of_points<double> modified_convex_cop;
+    modified_convex_cop.points.insert(modified_convex_cop.points.end(), convex_hull_A.begin(), convex_hull_A.end());
+    modified_convex_cop.points.emplace_back(midpoint_for_end_A);
+    modified_convex_cop.points.insert(modified_convex_cop.points.end(), convex_hull_B.begin(), convex_hull_B.end());
+    modified_convex_cop.points.emplace_back(midpoint_for_start_A);
+    modified_convex_cop.closed = true;
+
+    std::vector<vec3<double>> midpoints;
+    midpoints.emplace_back(midpoint_for_end_A);
+    midpoints.emplace_back(midpoint_for_start_A);
+
+    return std::make_tuple(modified_convex_cop, other_A, other_B, midpoints);
+}
+
+// creates faces by connecting non convex hull points to the midpoints based on distance
+// returns faces and associated ordered points
+std::tuple<std::vector<std::array<size_t, 3>>, std::vector<vec3<double>>>
+Mesh_Inner_Points_With_Midpoints(const std::list<vec3<double>> &left_points,
+                                 const std::list<vec3<double>> &right_points,
+                                 const std::vector<vec3<double>> &midpoints, const vec3<double> &pseudo_vert_offset) {
+    if(midpoints.size() != 2) {
+        YLOGWARN("Unable to handle " << midpoints.size() << " midpoints at this time.");
+        throw std::runtime_error("Unable to handle !=2 midpoints at this time.");
+    }
+
+    // compare distances by using midpoints on the same plane
+    auto midpoint1_flattened = midpoints[0] - pseudo_vert_offset;
+    auto midpoint2_flattened = midpoints[1] - pseudo_vert_offset;
+
+    int midpoint1_position = left_points.size() + right_points.size();
+    int midpoint2_position = midpoint1_position + 1;
+
+    std::vector<std::array<size_t, 3>> faces;
+
+    // adds face
+    // iterators must be of same vector
+    const auto add_points_with_midpoint =
+        [&](std::list<vec3<double>>::iterator point1_it, std::list<vec3<double>>::iterator point2_it,
+            std::list<vec3<double>>::iterator beg_it, const int offset, const int midpoint_index) -> void {
+        const auto v_a = static_cast<size_t>(offset + std::distance(beg_it, point1_it));
+        const auto v_b = static_cast<size_t>(offset + std::distance(beg_it, point2_it));
+        const auto v_c = static_cast<size_t>(midpoint_index);
+        faces.emplace_back(std::array<size_t, 3> { { v_a, v_b, v_c } });
+    };
+
+    const auto add_point_with_two_midpoints = [&](std::list<vec3<double>>::iterator point1_it,
+                                                  std::list<vec3<double>>::iterator beg_it, const int offset,
+                                                  const int midpoint1_index, const int midpoint2_index) -> void {
+        const auto v_a = static_cast<size_t>(offset + std::distance(beg_it, point1_it));
+        const auto v_b = static_cast<size_t>(midpoint1_index);
+        const auto v_c = static_cast<size_t>(midpoint2_index);
+        faces.emplace_back(std::array<size_t, 3> { { v_a, v_b, v_c } });
+    };
+
+    const auto create_faces_with_points = [&](std::list<vec3<double>> points, const int offset) -> void {
+        bool switched         = false;
+        auto closer_midpoint  = midpoint1_flattened;
+        auto closer_position  = midpoint1_position;
+        auto further_midpoint = midpoint2_flattened;
+        auto further_position = midpoint2_position;
+
+        if(points.begin()->sq_dist(closer_midpoint) > points.begin()->sq_dist(further_midpoint)) {
+            std::swap(closer_midpoint, further_midpoint);
+            std::swap(closer_position, further_position);
+        }
+
+        for(auto it = std::next(points.begin()); it != points.end(); it++) {
+            // assumes once switched, will not go back
+            auto point = *it;
+            if(point.sq_dist(closer_midpoint) < point.sq_dist(further_midpoint) && !switched) {
+                // create face with prev point and closer_midpoint
+                add_points_with_midpoint(it, std::prev(it), points.begin(), offset, closer_position);
+            } else {
+                if(!switched) {
+                    // connect to both points (two faces)
+                    add_points_with_midpoint(it, std::prev(it), points.begin(), offset, closer_position);
+                    add_point_with_two_midpoints(it, points.begin(), offset, closer_position, further_position);
+                    switched = true;
+                } else {
+                    // connect to prev point and further_midpoint
+                    add_points_with_midpoint(it, std::prev(it), points.begin(), offset, further_position);
+                }
+            }
+        }
+    };
+
+    create_faces_with_points(left_points, 0);
+    create_faces_with_points(right_points, left_points.size());
+
+    // make vector of all points (order is important for faces to be parsed correctly)
+    std::vector<vec3<double>> all_points(left_points.begin(), left_points.end());
+    all_points.insert(all_points.end(), right_points.begin(), right_points.end());
+    all_points.emplace_back(midpoints[0]);
+    all_points.emplace_back(midpoints[1]);
+
+    return std::make_tuple(faces, all_points);
+}
+
+// meshes 2 to 1 (will need to mesh convex hull contour with other contour outside of this routine)
+// returns non-convex hull faces, non-convex hull points, and convex hull contour (with midpoints)
+std::tuple<std::vector<std::array<size_t, 3>>, std::vector<vec3<double>>, contour_of_points<double>>
+Mesh_With_Convex_Hull_2(const std::list<std::reference_wrapper<contour_of_points<double>>> &A,
+                        const vec3<double> &ortho_unit_A, const vec3<double> &pseudo_vert_offset) {
+    if(A.size() != 2) {
+        throw std::runtime_error("Convex hull is currently only possible for 2 contours. Aborted.");
+    }
+    std::vector<contour_of_points<double>> list_of_cops;
+    for(auto &cop : A) {
+        auto new_cop = cop.get();
+        if (new_cop.points.front() == new_cop.points.back()) new_cop.points.pop_back();
+        list_of_cops.emplace_back(new_cop);
+    }
+    auto convex_hull_cop = Contour_From_Convex_Hull_2(list_of_cops, ortho_unit_A);
+    auto [modified_convex_cop, left_points, right_points, midpoints] =
+        Modify_Convex_Hull(convex_hull_cop, list_of_cops, pseudo_vert_offset);
+    auto [faces_from_non_convex, ordered_non_convex_points] =
+        Mesh_Inner_Points_With_Midpoints(left_points.points, right_points.points, midpoints, pseudo_vert_offset);
+
+    return std::make_tuple(faces_from_non_convex, ordered_non_convex_points, modified_convex_cop);
+}

--- a/src/Complex_Branching_Meshing.h
+++ b/src/Complex_Branching_Meshing.h
@@ -1,0 +1,61 @@
+//Complex_Branching_Meshing.h - A part of DICOMautomaton 2020. Written by hal clark.
+
+#pragma once
+
+#include <string>    
+#include <vector>
+#include <set> 
+#include <map>
+#include <unordered_map>
+#include <list>
+#include <functional>
+#include <thread>
+#include <array>
+#include <mutex>
+#include <limits>
+#include <cmath>
+
+#include <cstdlib>            //Needed for exit() calls.
+#include <utility>            //Needed for std::pair.
+#include <algorithm>
+#include <optional>
+
+#include "YgorMath.h"         //Needed for vec3 class.
+
+// returns contour of points of convex hull by following
+// https://www.geeksforgeeks.org/convex-hull-using-graham-scan/
+contour_of_points<double>
+Contour_From_Convex_Hull_2(
+    std::vector<contour_of_points<double>> &cops,
+    const vec3<double> &normal
+);
+
+// assumes there are only two contours in cops
+// modifies convex hull by adding midpoints and including more original contour points
+// returns closed modified convex hull, two non-convex hull contours (one for each original contour), and list of midpoints
+// the non-convex hull contours start and end with closest point on convex hull
+std::tuple<contour_of_points<double>,contour_of_points<double>,contour_of_points<double>, std::vector<vec3<double>>>
+Modify_Convex_Hull(
+    const contour_of_points<double> &convex_hull,
+    const std::vector<contour_of_points<double>> cops,
+    const vec3<double> &pseudo_vert_offset
+);
+
+// creates faces by connecting non convex hull points to the midpoints based on distance
+// returns faces and associated ordered points
+std::tuple<std::vector<std::array<size_t, 3>>, std::vector<vec3<double>>>
+Mesh_Inner_Points_With_Midpoints(
+    const std::list<vec3<double>> &left_points,
+    const std::list<vec3<double>> &right_points,
+    const std::vector<vec3<double>> &midpoints,
+    const vec3<double> &pseudo_vert_offset
+);
+
+// meshes 2 to 1 (will need to mesh convex hull contour with other contour outside of this routine)
+// returns non-convex hull faces, non-convex hull points, and convex hull contour (with midpoints)
+std::tuple<std::vector<std::array<size_t,3>>, std::vector<vec3<double>>, contour_of_points<double>>
+Mesh_With_Convex_Hull_2(
+    const std::list<std::reference_wrapper<contour_of_points<double>>> &A,
+    const vec3<double> &ortho_unit_A,
+    const vec3<double> &pseudo_vert_offset
+);

--- a/src/Operation_Dispatcher.cc
+++ b/src/Operation_Dispatcher.cc
@@ -67,6 +67,7 @@
 #include "Operations/CopyTables.h"
 #include "Operations/CopyPoints.h"
 #include "Operations/CountVoxels.h"
+#include "Operations/CreateCustomContour.h"
 #include "Operations/CropImageDoseToROIs.h"
 #include "Operations/CropImages.h"
 #include "Operations/CropROIDose.h"
@@ -310,6 +311,7 @@ std::map<std::string, op_packet_t> Known_Operations(){
     out["CopyTables"] = std::make_pair(OpArgDocCopyTables, CopyTables);
     out["CopyPoints"] = std::make_pair(OpArgDocCopyPoints, CopyPoints);
     out["CountVoxels"] = std::make_pair(OpArgDocCountVoxels, CountVoxels);
+    out["CreateCustomContour"] = std::make_pair(OpArgDocCreateCustomContour, CreateCustomContour);
     out["CropImageDoseToROIs"] = std::make_pair(OpArgDocCropImageDoseToROIs, CropImageDoseToROIs);
     out["CropImages"] = std::make_pair(OpArgDocCropImages, CropImages);
     out["CropROIDose"] = std::make_pair(OpArgDocCropROIDose, CropROIDose);

--- a/src/Operation_Dispatcher.cc
+++ b/src/Operation_Dispatcher.cc
@@ -37,6 +37,7 @@
 #include "Operations/BuildLexiconInteractively.h"
 #include "Operations/ClusterDBSCAN.h"
 #include "Operations/CombineMeshes.h"
+#include "Operations/CompareMeshes.h"
 #include "Operations/ComparePixels.h"
 #include "Operations/ContourBasedRayCastDoseAccumulate.h"
 #include "Operations/ContourSimilarity.h"
@@ -280,6 +281,7 @@ std::map<std::string, op_packet_t> Known_Operations(){
     out["CellularAutomata"] = std::make_pair(OpArgDocCellularAutomata, CellularAutomata);
     out["ClusterDBSCAN"] = std::make_pair(OpArgDocClusterDBSCAN, ClusterDBSCAN);
     out["CombineMeshes"] = std::make_pair(OpArgDocCombineMeshes, CombineMeshes);
+    out["CompareMeshes"] = std::make_pair(OpArgDocCompareMeshes, CompareMeshes);
     out["ComparePixels"] = std::make_pair(OpArgDocComparePixels, ComparePixels);
     out["ContourBasedRayCastDoseAccumulate"] = std::make_pair(OpArgDocContourBasedRayCastDoseAccumulate, ContourBasedRayCastDoseAccumulate);
     out["ContouringAides"] = std::make_pair(OpArgDocContouringAides, ContouringAides);

--- a/src/Operations/CMakeLists.txt
+++ b/src/Operations/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Operations_objs OBJECT
     BuildLexiconInteractively.cc
     ClusterDBSCAN.cc
     CombineMeshes.cc
+    CompareMeshes.cc
     ComparePixels.cc
     ContourBasedRayCastDoseAccumulate.cc
     ContouringAides.cc

--- a/src/Operations/CMakeLists.txt
+++ b/src/Operations/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(Operations_objs OBJECT
     CopyTables.cc
     CopyPoints.cc
     CountVoxels.cc
+    CreateCustomContour.cc
     CropImageDoseToROIs.cc
     CropImages.cc
     CropROIDose.cc

--- a/src/Operations/CompareMeshes.cc
+++ b/src/Operations/CompareMeshes.cc
@@ -80,10 +80,10 @@ bool CompareMeshes(Drover &DICOM_data,
     FUNCINFO("Iterating through " << size(mesh1->meshes.vertices) << " and " << size(mesh2->meshes.vertices) << " vertices.");
 
     // O(n^2) time, might be way to speed this up if this is ever a bottleneck
-    for (auto & vertex : mesh1->meshes.vertices) {
+    for (auto& vertex : mesh1->meshes.vertices) {
         // find closest vertex on mesh2 that corresponds to vertex
         double min_distance = -1;
-        for (auto & vertex2 : mesh2->meshes.vertices) {
+        for (auto& vertex2 : mesh2->meshes.vertices) {
             double distance = vertex.distance(vertex2);
             if (min_distance == -1) {
                 min_distance = distance;
@@ -96,10 +96,10 @@ bool CompareMeshes(Drover &DICOM_data,
 
     double second_max_distance = 0;
 
-    for (auto & vertex : mesh2->meshes.vertices) {
+    for (auto& vertex : mesh2->meshes.vertices) {
         // find closest vertex on mesh2 that corresponds to vertex
         double min_distance = -1;
-        for (auto & vertex2 : mesh1->meshes.vertices) {
+        for (auto& vertex2 : mesh1->meshes.vertices) {
             double distance = vertex.distance(vertex2);
             if (min_distance == -1) {
                 min_distance = distance;
@@ -109,7 +109,31 @@ bool CompareMeshes(Drover &DICOM_data,
         }
         second_max_distance = std::max(min_distance, second_max_distance);
     }
+
+    // Calculate centroids by finding the average of all the vertices in the surface mesh
+    //Assumes that contours vertices are distributed evenly on the surface mesh which is not strictly true.
+    double sumx = 0, sumy = 0, sumz = 0;
+    for (auto& vertex : mesh1->meshes.vertices) {
+        sumx += vertex.x;
+        sumy += vertex.y;
+        sumz += vertex.z;
+    }
+    vec3 centroid1 = vec3(sumx/size(mesh1->meshes.vertices) , sumy/size(mesh1->meshes.vertices) , sumz/size(mesh1->meshes.vertices));
+
+    sumx = 0, sumy= 0, sumz = 0;
+    for (auto& vertex : mesh2->meshes.vertices) {
+        sumx += vertex.x;
+        sumy += vertex.y;
+        sumz += vertex.z;
+    }
+    vec3 centroid2 = vec3(sumx/size(mesh1->meshes.vertices) , sumy/size(mesh1->meshes.vertices) , sumz/size(mesh1->meshes.vertices));
+
+    const double centroid_shift = sqrt(pow((centroid2.x-centroid1.x),2) + pow((centroid2.y-centroid1.y),2) + pow((centroid2.y-centroid1.y),2));
     
+    //Converting to a triangular mesh to ensure that each face is made up of 3 vertices for volume calculation
+    //Total volume is calculated by summing the signed volme of the triganular prism made by each face and the origin as the apex.
+    //This method returns a finite volume even if the mesh is open, so watertightness needs to be checked separately.
+
     mesh1->meshes.convert_to_triangles();
     mesh2->meshes.convert_to_triangles();
 
@@ -118,7 +142,7 @@ bool CompareMeshes(Drover &DICOM_data,
     double volume2 = 0;
 
     decltype(mesh1->meshes.faces)* faces = &(mesh1->meshes.faces);
-    for (auto & fv : *faces){
+    for (auto& fv : *faces){
 
         const auto P_A = mesh1->meshes.vertices.at( fv[0] );
         const auto P_B = mesh1->meshes.vertices.at( fv[1] );
@@ -128,31 +152,31 @@ bool CompareMeshes(Drover &DICOM_data,
                 P_C.x*P_A.y*P_B.z - P_A.x*P_C.y*P_B.z - 
                 P_B.x*P_A.y*P_C.z + P_A.x*P_B.y*P_C.z)/(6.0);
 
-        }
-
-    FUNCINFO("vol1 = "<<abs(volume1)<<".")
+    }
 
 
     faces = &(mesh2->meshes.faces);
-    for (auto & fv : *faces){
+    for (auto& fv : *faces){
 
         const auto P_A = mesh2->meshes.vertices.at( fv[0] );
         const auto P_B = mesh2->meshes.vertices.at( fv[1] );
         const auto P_C = mesh2->meshes.vertices.at( fv[2] );
 
-        volume2 += (-P_C.x*P_B.y*P_A.z + P_B.x*P_C.y*P_A.z + 
+        volume2 += (-P_C.x*P_B.y*P_A.z + P_B.x*P_C.y*P_A.z +
                 P_C.x*P_A.y*P_B.z - P_A.x*P_C.y*P_B.z - 
                 P_B.x*P_A.y*P_C.z + P_A.x*P_B.y*P_C.z)/(6.0);
-        }
+    }
 
-    FUNCINFO("vol2 = "<<abs(volume2)<<".")
-    FUNCINFO("diffVol = "<<abs(abs(volume1)-abs(volume2)))
+    
 
     FUNCINFO("HAUSDORFF DISTANCE: " << max_distance << " or " << second_max_distance);
-
-    // print out surface areas
     FUNCINFO("SURFACE AREA: First mesh = " << mesh1->meshes.surface_area() << ", second mesh = " << mesh2->meshes.surface_area());
-    FUNCINFO("SURFACE AREA difference: " << mesh1->meshes.surface_area() - mesh2->meshes.surface_area());
+    FUNCINFO("SURFACE AREA (%) difference: " << (mesh1->meshes.surface_area() - mesh2->meshes.surface_area())*100/mesh1->meshes.surface_area());
+    FUNCINFO("VOLUME: First mesh = " <<abs(volume1) << ", second mesh = " << abs(volume2));
+    FUNCINFO("VOLUME (%) difference: " << (abs(abs(volume1)-abs(volume2)))*100/abs(volume1));
+    FUNCINFO("CENTROID: First mesh = " << centroid1.x << "," << centroid1.y << "," << centroid1.z)
+    FUNCINFO("CENTROID: Second mesh = " << centroid2.x << "," << centroid2.y << "," << centroid2.z)
+    FUNCINFO("Centroid Shift = " << centroid_shift)
 
     return true;
 }

--- a/src/Operations/CompareMeshes.cc
+++ b/src/Operations/CompareMeshes.cc
@@ -1,0 +1,120 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>            //Needed for exit() calls.
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <list>
+#include <map>
+#include <memory>
+#include <set> 
+#include <stdexcept>
+#include <string>    
+#include <random>
+
+#include "YgorMath.h"         //Needed for vec3 class.
+#include "YgorMathIOOBJ.h"
+#include "YgorMisc.h"         //Needed for FUNCINFO, FUNCWARN, FUNCERR macros.
+
+#include "Explicator.h"
+
+#include "../Contour_Boolean_Operations.h"
+#include "../Structs.h"
+#include "../Regex_Selectors.h"
+
+#include "../Simple_Meshing.h"
+#include "../Surface_Meshes.h"
+
+#include "CompareMeshes.h"
+
+OperationDoc OpArgDocCompareMeshes(){
+    OperationDoc out;
+    out.name = "CompareMeshes";
+
+    out.desc = 
+        "This routine calculates various metrics of difference between two meshes and prints it to the terminal output."
+        ;
+
+
+    out.args.emplace_back();
+    out.args.back() = SMWhitelistOpArgDoc();
+    out.args.back().name = "MeshSelection1";
+    out.args.back().default_val = "#-0";
+    out.args.emplace_back();
+    out.args.back() = SMWhitelistOpArgDoc();
+    out.args.back().name = "MeshSelection2";
+    out.args.back().default_val = "#-1";
+
+    return out;
+}
+
+bool CompareMeshes(Drover &DICOM_data,
+                               const OperationArgPkg& OptArgs,
+                               std::map<std::string, std::string>& /*InvocationMetadata*/,
+                               const std::string& FilenameLex){
+
+    Explicator X(FilenameLex);
+
+    //---------------------------------------------- User Parameters --------------------------------------------------
+    const auto MeshSelection1Str = OptArgs.getValueStr("MeshSelection1").value();
+    const auto MeshSelection2Str = OptArgs.getValueStr("MeshSelection2").value();
+
+    //-----------------------------------------------------------------------------------------------------------------
+    auto SMs_all = All_SMs( DICOM_data );
+    auto SMs1 = Whitelist( SMs_all, MeshSelection1Str );
+    auto SMs2 = Whitelist( SMs_all, MeshSelection2Str );
+
+
+    if (SMs1.size() < 1 || SMs2.size() < 1) {
+        FUNCERR("Must select at least two meshes.");
+    }
+    if (SMs1.size() > 1 || SMs2.size() > 1) {
+        FUNCWARN("Can only calculate the metrics of two meshes, only looking at last element of each selected");
+    }
+    
+    std::shared_ptr<Surface_Mesh> mesh1 = *SMs1.front();
+    std::shared_ptr<Surface_Mesh> mesh2 = *SMs2.front();
+
+    double max_distance = 0;
+
+    FUNCINFO("Iterating through " << size(mesh1->meshes.vertices) << " and " << size(mesh2->meshes.vertices) << " vertices.");
+
+    // O(n^2) time, might be way to speed this up if this is ever a bottleneck
+    for (auto & vertex : mesh1->meshes.vertices) {
+        // find closest vertex on mesh2 that corresponds to vertex
+        double min_distance = -1;
+        for (auto & vertex2 : mesh2->meshes.vertices) {
+            double distance = vertex.distance(vertex2);
+            if (min_distance == -1) {
+                min_distance = distance;
+            } else {
+                min_distance = std::min(distance, min_distance);
+            }
+        }
+        max_distance = std::max(min_distance, max_distance);
+    }
+
+    double second_max_distance = 0;
+
+    for (auto & vertex : mesh2->meshes.vertices) {
+        // find closest vertex on mesh2 that corresponds to vertex
+        double min_distance = -1;
+        for (auto & vertex2 : mesh1->meshes.vertices) {
+            double distance = vertex.distance(vertex2);
+            if (min_distance == -1) {
+                min_distance = distance;
+            } else {
+                min_distance = std::min(distance, min_distance);
+            }
+        }
+        second_max_distance = std::max(min_distance, second_max_distance);
+    }
+
+    FUNCINFO("HAUSDORFF DISTANCE: " << max_distance << " or " << second_max_distance);
+
+    // print out surface areas
+    FUNCINFO("SURFACE AREA: First mesh = " << mesh1->meshes.surface_area() << ", second mesh = " << mesh2->meshes.surface_area());
+    FUNCINFO("SURFACE AREA difference: " << mesh1->meshes.surface_area() - mesh2->meshes.surface_area());
+
+    return true;
+}

--- a/src/Operations/CompareMeshes.cc
+++ b/src/Operations/CompareMeshes.cc
@@ -92,11 +92,6 @@ bool IsEdgeManifold(const std::shared_ptr<Surface_Mesh> &mesh) {
     std::map<std::set<uint64_t>, int> edge_counts;
     auto mesh_faces = GetCleanFaces(mesh);
     int face_count = 0;
-    // YLOGINFO("Printing vertices for mesh");
-    // for (auto &face : mesh.get()->meshes.faces) {
-    //     YLOGINFO(face_count << " face vertex indices " << face[0] << ", " << face[1] << ", " << face[2] << " with size " << face.size());
-    //     face_count++;
-    // }
 
     face_count = 0;
     for (auto &face : mesh_faces) {
@@ -105,11 +100,7 @@ bool IsEdgeManifold(const std::shared_ptr<Surface_Mesh> &mesh) {
 
         for (auto &edge : edges) {
             edge_counts[edge] += 1;
-            // auto itt = edge.begin();
-            // YLOGINFO("Edge count = " << edge_counts[edge] << " for edge " << *itt << ", " << *(std::next(itt)));
             if (edge_counts[edge] > 2) {
-                // auto it = edge.begin();
-                // YLOGINFO("edge count > 2 for edge " << *it << ", " << *(std::next(it)) << " for face #" << face_count);
                 return false;
             }
         }
@@ -118,7 +109,6 @@ bool IsEdgeManifold(const std::shared_ptr<Surface_Mesh> &mesh) {
 
     for (auto &key_value_pair : edge_counts) {
         if (key_value_pair.second != 2) {
-            // YLOGINFO("edge count is " << key_value_pair.second);
             return false;
         }
     }
@@ -130,10 +120,6 @@ bool IsEdgeManifold(const std::shared_ptr<Surface_Mesh> &mesh) {
 // it is vertex manifold when each vertex's faces form an open or closed fan
 // https://www.mathworks.com/help/lidar/ref/surfacemesh.isvertexmanifold.html
 bool IsVertexManifold(const std::shared_ptr<Surface_Mesh>&mesh) {
-    // for each face, find faces with same edges and add to search
-    // keep searching until you hit a face you look for before (closed) or ended
-    // is there still faces unsearched? 
-
     // store vertex to face hashmap
     // for each vertex, store edge to list of faces
     // start with a face
@@ -246,14 +232,18 @@ bool CompareMeshes(Drover &DICOM_data,
     }
 
     // Calculate centroids by finding the average of all the vertices in the surface mesh
-    //Assumes that contours vertices are distributed evenly on the surface mesh which is not strictly true.
+    // Assumes that contours vertices are distributed evenly on the surface mesh which is not strictly true.
     double sumx = 0, sumy = 0, sumz = 0;
     for (auto& vertex : mesh1->meshes.vertices) {
         sumx += vertex.x;
         sumy += vertex.y;
         sumz += vertex.z;
     }
-    vec3 centroid1 = vec3(sumx/size(mesh1->meshes.vertices) , sumy/size(mesh1->meshes.vertices) , sumz/size(mesh1->meshes.vertices));
+    vec3 centroid1 = vec3(
+        sumx/size(mesh1->meshes.vertices),
+        sumy/size(mesh1->meshes.vertices),
+        sumz/size(mesh1->meshes.vertices)
+    );
 
     sumx = 0, sumy= 0, sumz = 0;
     for (auto& vertex : mesh2->meshes.vertices) {
@@ -265,9 +255,9 @@ bool CompareMeshes(Drover &DICOM_data,
 
     const double centroid_shift = sqrt(pow((centroid2.x-centroid1.x),2) + pow((centroid2.y-centroid1.y),2) + pow((centroid2.y-centroid1.y),2));
     
-    //Converting to a triangular mesh to ensure that each face is made up of 3 vertices for volume calculation
-    //Total volume is calculated by summing the signed volme of the triganular prism made by each face and the origin as the apex.
-    //This method returns a finite volume even if the mesh is open, so watertightness needs to be checked separately.
+    // Converting to a triangular mesh to ensure that each face is made up of 3 vertices for volume calculation
+    // Total volume is calculated by summing the signed volme of the triganular prism made by each face and the origin as the apex.
+    // This method returns a finite volume even if the mesh is open, so watertightness needs to be checked separately.
 
     mesh1->meshes.convert_to_triangles();
     mesh2->meshes.convert_to_triangles();
@@ -306,8 +296,8 @@ bool CompareMeshes(Drover &DICOM_data,
     bool v_manifold_2 = IsVertexManifold(mesh2);
     bool e_manifold_1 = IsEdgeManifold(mesh1);
     bool e_manifold_2 = IsEdgeManifold(mesh2);
-    FUNCINFO("Vertex manifoldness: " << v_manifold_1 << " and " << v_manifold_2);
-    FUNCINFO("Edge manifoldness: " << e_manifold_1 << " and " << e_manifold_2);
+    FUNCINFO("Vertex manifoldness (first vs. second): " << v_manifold_1 << " and " << v_manifold_2);
+    FUNCINFO("Edge manifoldness (first vs. second): " << e_manifold_1 << " and " << e_manifold_2);
 
     bool manifold1 = v_manifold_1 && e_manifold_1;
     bool manifold2 = v_manifold_2 && e_manifold_2;

--- a/src/Operations/CompareMeshes.cc
+++ b/src/Operations/CompareMeshes.cc
@@ -109,6 +109,44 @@ bool CompareMeshes(Drover &DICOM_data,
         }
         second_max_distance = std::max(min_distance, second_max_distance);
     }
+    
+    mesh1->meshes.convert_to_triangles();
+    mesh2->meshes.convert_to_triangles();
+
+
+    double volume1 = 0;
+    double volume2 = 0;
+
+    decltype(mesh1->meshes.faces)* faces = &(mesh1->meshes.faces);
+    for (auto & fv : *faces){
+
+        const auto P_A = mesh1->meshes.vertices.at( fv[0] );
+        const auto P_B = mesh1->meshes.vertices.at( fv[1] );
+        const auto P_C = mesh1->meshes.vertices.at( fv[2] );
+
+        volume1 += (-P_C.x*P_B.y*P_A.z + P_B.x*P_C.y*P_A.z + 
+                P_C.x*P_A.y*P_B.z - P_A.x*P_C.y*P_B.z - 
+                P_B.x*P_A.y*P_C.z + P_A.x*P_B.y*P_C.z)/(6.0);
+
+        }
+
+    FUNCINFO("vol1 = "<<abs(volume1)<<".")
+
+
+    faces = &(mesh2->meshes.faces);
+    for (auto & fv : *faces){
+
+        const auto P_A = mesh2->meshes.vertices.at( fv[0] );
+        const auto P_B = mesh2->meshes.vertices.at( fv[1] );
+        const auto P_C = mesh2->meshes.vertices.at( fv[2] );
+
+        volume2 += (-P_C.x*P_B.y*P_A.z + P_B.x*P_C.y*P_A.z + 
+                P_C.x*P_A.y*P_B.z - P_A.x*P_C.y*P_B.z - 
+                P_B.x*P_A.y*P_C.z + P_A.x*P_B.y*P_C.z)/(6.0);
+        }
+
+    FUNCINFO("vol2 = "<<abs(volume2)<<".")
+    FUNCINFO("diffVol = "<<abs(abs(volume1)-abs(volume2)))
 
     FUNCINFO("HAUSDORFF DISTANCE: " << max_distance << " or " << second_max_distance);
 

--- a/src/Operations/CompareMeshes.h
+++ b/src/Operations/CompareMeshes.h
@@ -1,0 +1,16 @@
+// CompareMeshes.h.
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "../Structs.h"
+
+
+OperationDoc OpArgDocCompareMeshes();
+
+bool CompareMeshes(Drover &DICOM_data,
+                               const OperationArgPkg& /*OptArgs*/,
+                               std::map<std::string, std::string>& /*InvocationMetadata*/,
+                               const std::string& /*FilenameLex*/);

--- a/src/Operations/ConvertContoursToMeshes.cc
+++ b/src/Operations/ConvertContoursToMeshes.cc
@@ -617,7 +617,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                             auto [faces, points, amal_upper] = Mesh_With_Convex_Hull_2(pcs.upper, m_cp_it->N_0, ofst_upper);
                             add_faces_and_vertices(faces, points);
                             auto amal_lower = pcs.lower.begin()->get();
-                            auto new_faces = Estimate_Contour_Correspondence(std::ref(amal_upper), std::ref(amal_lower));
+                            auto new_faces = Tile_Contours(std::ref(amal_upper), std::ref(amal_lower));
                             add_faces_to_mesh(std::ref(amal_upper), std::ref(amal_lower), new_faces);
                         } catch (const std::runtime_error& error) {
                             goto generic_n_to_n_meshing;
@@ -647,7 +647,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                             auto [faces, points, amal_lower] = Mesh_With_Convex_Hull_2(pcs.lower, l_cp_it->N_0, ofst_lower);
                             add_faces_and_vertices(faces, points);
                             auto amal_upper = pcs.upper.begin()->get();
-                            auto new_faces = Estimate_Contour_Correspondence(std::ref(amal_upper), std::ref(amal_lower));
+                            auto new_faces = Tile_Contours(std::ref(amal_upper), std::ref(amal_lower));
                             add_faces_to_mesh(std::ref(amal_upper), std::ref(amal_lower), new_faces);    
                         } catch (const std::runtime_error& error) {
                             goto generic_n_to_n_meshing;
@@ -717,7 +717,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
         OverwriteStringToFile(amal_cop_str, fname);
     }
     */
-                        auto new_faces = Estimate_Contour_Correspondence(std::ref(amal_upper), std::ref(amal_lower));
+                        auto new_faces = Tile_Contours(std::ref(amal_upper), std::ref(amal_lower));
                         add_faces_to_mesh(std::ref(amal_upper), std::ref(amal_lower), new_faces);
                     }
                 }

--- a/src/Operations/ConvertContoursToMeshes.cc
+++ b/src/Operations/ConvertContoursToMeshes.cc
@@ -150,6 +150,7 @@ OperationDoc OpArgDocConvertContoursToMeshes(){
 }
 
 
+
 bool ConvertContoursToMeshes(Drover &DICOM_data,
                                const OperationArgPkg& OptArgs,
                                std::map<std::string, std::string>& /*InvocationMetadata*/,
@@ -471,6 +472,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
 
                 // Convert from integer numbering to direct pairing info.
                 for(const auto &p : pairs){
+
                     pairings.emplace_back();
                     for(const auto &u : p.upper){
                         pairings.back().upper.emplace_back( *std::next( std::begin(m_cops), u ) );
@@ -543,7 +545,6 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                 std::vector<vec3<double>> &points
                 ) -> void {
                     const auto old_face_count = amesh.vertices.size();
-                    // for(const auto &p : points) amesh.vertices.emplace_back(p);
                     amesh.vertices.insert(amesh.vertices.end(), points.begin(), points.end());
                     for(const auto &fs : new_faces){
                         const auto f_A = static_cast<uint64_t>(fs[0] + old_face_count);
@@ -593,7 +594,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                     /* auto new_faces = Estimate_Contour_Correspondence(pcs.upper.front(), pcs.lower.front()); */
                     auto new_faces = Tile_Contours(pcs.upper.front(), pcs.lower.front());
                     add_faces_to_mesh(pcs.upper.front(), pcs.lower.front(), new_faces);
-                }else if((N_upper == 2) && (N_lower == 1) ){
+                }else if( (N_upper == 2) && (N_lower == 1) ){
                     //check if the upper plane contains enclosed contours
                         if(contours_are_enclosed(*m_cp_it, pcs.upper.front(), pcs.upper.back())){
                         //get contour areas to determine which contour is enclosed by the other
@@ -633,7 +634,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                         const auto c2_area = std::abs(contour->get().Get_Signed_Area());
 
                         //cap the smaller contour and tile the larger contour with the lower plane contour
-                        if  (c1_area < c2_area){
+                        if(c1_area < c2_area){
                             close_hole_in_roof(pcs.lower.front());
                             auto new_faces = Tile_Contours(pcs.lower.back(), pcs.upper.front());
                             add_faces_to_mesh(pcs.lower.back(), pcs.upper.front(), new_faces);
@@ -657,7 +658,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                     //YLOGINFO("Performing N-to-N meshing..");
 
                     //routine for hollow structures with an inner contour and an outer contour on both planes
-                    if((N_upper == 2) && (N_lower == 2)){
+                    if( (N_upper == 2) && (N_lower == 2) ){
                         //check if both planes have enclosed contours
                         if (contours_are_enclosed(*m_cp_it, pcs.upper.front(), pcs.upper.back())
                             && contours_are_enclosed(*l_cp_it, pcs.lower.front(), pcs.lower.back())){
@@ -704,6 +705,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                         generic_n_to_n_meshing:
                         auto amal_upper = Minimally_Amalgamate_Contours(m_cp_it->N_0, ofst_upper, pcs.upper); 
                         auto amal_lower = Minimally_Amalgamate_Contours(m_cp_it->N_0, ofst_lower, pcs.lower);
+                        
     /*
     // Leaving this here for future debugging, for which it will no-doubt be needed...
     {

--- a/src/Operations/ConvertContoursToMeshes.cc
+++ b/src/Operations/ConvertContoursToMeshes.cc
@@ -202,7 +202,14 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
     if(std::regex_match(MethodStr, direct_regex)){
         // Identify the unique planes.
         //const auto est_cont_normal = cc.contours.front().Estimate_Planar_Normal();
-        const auto est_cont_normal = Average_Contour_Normals(cc_ref);
+        const auto est_cont_normal = [&]() {
+            auto est_cont_normal = Average_Contour_Normals(cc_ref);
+            if(!est_cont_normal.isfinite()) {
+                est_cont_normal = cc_ref.front().get().contours.front().Estimate_Planar_Normal();
+            };
+            return est_cont_normal;
+        }();
+
         const auto contour_sep_eps = 0.005;
         auto ucps = Unique_Contour_Planes(cc_ref, est_cont_normal, contour_sep_eps);
         if(ucps.size() < 2){

--- a/src/Operations/ConvertContoursToMeshes.cc
+++ b/src/Operations/ConvertContoursToMeshes.cc
@@ -569,7 +569,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                     //this routine is for pipe like structures.
                     if(N_upper == 2){
                         if(contours_are_enclosed(*m_cp_it, pcs.upper.front(), pcs.upper.back())){
-                            auto new_faces = Estimate_Contour_Correspondence(pcs.upper.front(), pcs.upper.back());
+                            auto new_faces = Tile_Contours(pcs.upper.front(), pcs.upper.back());
                             add_faces_to_mesh(pcs.upper.front(), pcs.upper.back(), new_faces);
                         }
                     }else{
@@ -582,7 +582,7 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                     //this routine is for pipe like structures.
                     if (N_lower == 2){
                         if(contours_are_enclosed(*l_cp_it, pcs.lower.front(), pcs.lower.back())){
-                            auto new_faces = Estimate_Contour_Correspondence(pcs.lower.front(), pcs.lower.back());
+                            auto new_faces = Tile_Contours(pcs.lower.front(), pcs.lower.back());
                             add_faces_to_mesh(pcs.lower.front(), pcs.lower.back(), new_faces);
                         }
                     }else{
@@ -590,7 +590,8 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                     }
 
                 }else if( (N_upper == 1) && (N_lower == 1) ){
-                    auto new_faces = Estimate_Contour_Correspondence(pcs.upper.front(), pcs.lower.front());
+                    /* auto new_faces = Estimate_Contour_Correspondence(pcs.upper.front(), pcs.lower.front()); */
+                    auto new_faces = Tile_Contours(pcs.upper.front(), pcs.lower.front());
                     add_faces_to_mesh(pcs.upper.front(), pcs.lower.front(), new_faces);
                 }else if((N_upper == 2) && (N_lower == 1) ){
                     //check if the upper plane contains enclosed contours
@@ -604,11 +605,11 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                         //cap the smaller contour and tile the larger contour with the lower plane contour
                         if  (c1_area < c2_area){
                             close_hole_in_floor(pcs.upper.front());
-                            auto new_faces = Estimate_Contour_Correspondence(pcs.upper.back(), pcs.lower.front());
+                            auto new_faces = Tile_Contours(pcs.upper.back(), pcs.lower.front());
                             add_faces_to_mesh(pcs.upper.back(), pcs.lower.front(), new_faces);
                         }else{
                             close_hole_in_floor(pcs.upper.back());
-                            auto new_faces = Estimate_Contour_Correspondence(pcs.upper.front(), pcs.lower.front());
+                            auto new_faces = Tile_Contours(pcs.upper.front(), pcs.lower.front());
                             add_faces_to_mesh(pcs.upper.front(), pcs.lower.front(), new_faces);
                         }
                     }else{
@@ -634,11 +635,11 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                         //cap the smaller contour and tile the larger contour with the lower plane contour
                         if  (c1_area < c2_area){
                             close_hole_in_roof(pcs.lower.front());
-                            auto new_faces = Estimate_Contour_Correspondence(pcs.lower.back(), pcs.upper.front());
+                            auto new_faces = Tile_Contours(pcs.lower.back(), pcs.upper.front());
                             add_faces_to_mesh(pcs.lower.back(), pcs.upper.front(), new_faces);
                         }else{
                             close_hole_in_roof(pcs.lower.back());
-                            auto new_faces = Estimate_Contour_Correspondence(pcs.lower.front(), pcs.upper.front());
+                            auto new_faces = Tile_Contours(pcs.lower.front(), pcs.upper.front());
                             add_faces_to_mesh(pcs.lower.front(), pcs.upper.front(), new_faces);
                         }
                     }else{
@@ -691,10 +692,10 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
                             }
 
                             //connect inner contours together and outer contours together
-                            auto new_faces = Estimate_Contour_Correspondence(lower_inner, upper_inner);
+                            auto new_faces = Tile_Contours(lower_inner, upper_inner);
                             add_faces_to_mesh(lower_inner, upper_inner, new_faces);
                             
-                            new_faces = Estimate_Contour_Correspondence(lower_outer, upper_outer);
+                            new_faces = Tile_Contours(lower_outer, upper_outer);
                             add_faces_to_mesh(lower_outer, upper_outer, new_faces);
                             //move to next iteration of for loop since we have tiled it
                             continue;

--- a/src/Operations/CreateCustomContour.cc
+++ b/src/Operations/CreateCustomContour.cc
@@ -59,6 +59,58 @@ bool CreateCustomContour(Drover &DICOM_data,
     // the original holding containers (which are not modified here).
     YLOGINFO("The X values are " << XValues);
     YLOGINFO("The Y values are " << YValues);
-    YLOGINFO("The Z values are " << YValues);
+    YLOGINFO("The Z values are " << ZValues);
+
+    contour_of_points<double> cop;
+    contour_collection<double> cc;
+
+    cop.closed = true;
+
+    std::vector<double> x_values = ValueStringToDoubleList(XValues);
+    std::vector<double> y_values = ValueStringToDoubleList(YValues);
+    std::vector<double> z_values = ValueStringToDoubleList(ZValues);
+
+    if(x_values.size()!=y_values.size()||y_values.size()!=z_values.size()) {
+        YLOGWARN("Each list must have the same number of numbers");
+        return true;
+    }
+
+    if(x_values.size() < 3) {
+        YLOGWARN("We require more than 3 points to be in a contour");
+        return true;
+    }
+
+    for(int i = 0; i < x_values.size(); i++) {
+        const vec3<double> p(static_cast<double>(x_values[i]), 
+                            static_cast<double>(y_values[i]),
+                            static_cast<double>(z_values[i]));
+        cop.points.emplace_back(p);
+    }
+    cop.metadata["ROILabel"] = ROILabel;
+
+    cc.contours.emplace_back(cop);
+
+    DICOM_data.Ensure_Contour_Data_Allocated();
+    DICOM_data.contour_data->ccs.emplace_back(cc);
     return true;
 }
+
+std::vector<double> ValueStringToDoubleList(std::string input) {
+    std::vector<double> values;
+    size_t pos = 0;
+    std::string delimiter = " ";
+    std::string token;
+    while ((pos = input.find(delimiter)) != std::string::npos) {
+        token = input.substr(0, pos);
+        try {
+            values.emplace_back(stod(token));
+            std::string error_message = "Invalid Input";
+        } catch(std::string error_message) {
+            YLOGWARN(error_message);
+            return std::vector<double>();
+        }
+        input.erase(0, pos + delimiter.length());
+    }
+    return values;
+}
+

--- a/src/Operations/CreateCustomContour.cc
+++ b/src/Operations/CreateCustomContour.cc
@@ -1,0 +1,64 @@
+
+//CopyContours.cc - A part of DICOMautomaton 2021. Written by hal clark.
+
+#include <list>
+#include <map>
+#include <string>
+
+#include "../Structs.h"
+#include "YgorLog.h"
+
+#include "CreateCustomContour.h"
+
+OperationDoc OpArgDocCreateCustomContour(){
+    OperationDoc out;
+    out.name = "CreateCustomContour";
+
+    out.desc = 
+        "This operation creates a new contour from a list of x, y, and z coordinates.";
+
+    out.args.emplace_back();
+    out.args.back().name = "ROILabel";
+    out.args.back().desc = "A label to attach to the copied ROI contours.";
+    out.args.back().default_val = "unspecified";
+    out.args.back().expected = true;
+
+    out.args.emplace_back();
+    out.args.back().name = "XValues";
+    out.args.back().desc = "List of X coordinates of the points in the contour";
+    out.args.back().default_val = "0";
+    out.args.back().expected = true;
+
+    out.args.emplace_back();
+    out.args.back().name = "YValues";
+    out.args.back().desc = "List of Y coordinates of the points in the contour";
+    out.args.back().default_val = "0";
+    out.args.back().expected = true;
+
+    out.args.emplace_back();
+    out.args.back().name = "ZValues";
+    out.args.back().desc = "List of Z coordinates of the points in the contour";
+    out.args.back().default_val = "0";
+    out.args.back().expected = true;
+    return out;
+}
+
+bool CreateCustomContour(Drover &DICOM_data,
+                    const OperationArgPkg& OptArgs,
+                    std::map<std::string, std::string>& /*InvocationMetadata*/,
+                    const std::string& FilenameLex){
+
+    //---------------------------------------------- User Parameters --------------------------------------------------
+    const auto ROILabel = OptArgs.getValueStr("ROILabel").value();
+    const auto XValues = OptArgs.getValueStr("XValues").value();
+    const auto YValues = OptArgs.getValueStr("YValues").value();
+    const auto ZValues = OptArgs.getValueStr("ZValues").value();
+    //-----------------------------------------------------------------------------------------------------------------
+
+    //Stuff references to all contours into a list. Remember that you can still address specific contours through
+    // the original holding containers (which are not modified here).
+    YLOGINFO("The X values are " << XValues);
+    YLOGINFO("The Y values are " << YValues);
+    YLOGINFO("The Z values are " << YValues);
+    return true;
+}

--- a/src/Operations/CreateCustomContour.cc
+++ b/src/Operations/CreateCustomContour.cc
@@ -3,7 +3,6 @@
 
 #include <list>
 #include <map>
-#include <string>
 
 #include "../Structs.h"
 #include "YgorLog.h"
@@ -25,19 +24,19 @@ OperationDoc OpArgDocCreateCustomContour(){
 
     out.args.emplace_back();
     out.args.back().name = "XValues";
-    out.args.back().desc = "List of X coordinates of the points in the contour";
+    out.args.back().desc = "List of contours separated by | character, where each countour is a list of doubles separated by spaces. Contains x-values";
     out.args.back().default_val = "0";
     out.args.back().expected = true;
 
     out.args.emplace_back();
     out.args.back().name = "YValues";
-    out.args.back().desc = "List of Y coordinates of the points in the contour";
+    out.args.back().desc = "List of contours separated by | character, where each countour is a list of doubles separated by spaces. Contains y-values";
     out.args.back().default_val = "0";
     out.args.back().expected = true;
 
     out.args.emplace_back();
     out.args.back().name = "ZValues";
-    out.args.back().desc = "List of Z coordinates of the points in the contour";
+    out.args.back().desc = "List of contours separated by | character, where each countour is a list of doubles separated by spaces. Contains z-values";
     out.args.back().default_val = "0";
     out.args.back().expected = true;
     return out;
@@ -61,56 +60,88 @@ bool CreateCustomContour(Drover &DICOM_data,
     YLOGINFO("The Y values are " << YValues);
     YLOGINFO("The Z values are " << ZValues);
 
-    contour_of_points<double> cop;
     contour_collection<double> cc;
 
-    cop.closed = true;
+    std::vector<std::string> x_contours = SplitString(XValues, "|");
+    std::vector<std::string> y_contours = SplitString(YValues, "|");
+    std::vector<std::string> z_contours = SplitString(ZValues, "|");
+    
 
-    std::vector<double> x_values = ValueStringToDoubleList(XValues);
-    std::vector<double> y_values = ValueStringToDoubleList(YValues);
-    std::vector<double> z_values = ValueStringToDoubleList(ZValues);
-
-    if(x_values.size()!=y_values.size()||y_values.size()!=z_values.size()) {
-        YLOGWARN("Each list must have the same number of numbers");
+    if(x_contours.size()!=y_contours.size()||y_contours.size()!=z_contours.size()) {
+        YLOGWARN("Ensure same number of contours for each dimension");
         return true;
     }
 
-    if(x_values.size() < 3) {
-        YLOGWARN("We require more than 3 points to be in a contour");
+    if(x_contours.size() < 1) {
+        YLOGWARN("We require that there is at least one contour.");
         return true;
     }
-
-    for(int i = 0; i < x_values.size(); i++) {
-        const vec3<double> p(static_cast<double>(x_values[i]), 
-                            static_cast<double>(y_values[i]),
-                            static_cast<double>(z_values[i]));
-        cop.points.emplace_back(p);
-    }
-    cop.metadata["ROILabel"] = ROILabel;
-
-    cc.contours.emplace_back(cop);
 
     DICOM_data.Ensure_Contour_Data_Allocated();
+    
+    std::vector<std::vector<double>> x_cops;
+    std::vector<std::vector<double>> y_cops;
+    std::vector<std::vector<double>> z_cops;
+
+    for(int i = 0; i < x_contours.size(); i++) {
+        std::vector<std::string> x_cop_string = SplitString(x_contours[i], " ");
+        std::vector<std::string> y_cop_string = SplitString(y_contours[i], " ");
+        std::vector<std::string> z_cop_string = SplitString(z_contours[i], " ");
+        if(x_cop_string.size()!=y_cop_string.size()||y_cop_string.size()!=z_cop_string.size()) {
+            YLOGWARN("Ensure each contour has the same number of points for each dimension");
+        }
+        if(x_cop_string.size() < 3) {
+            YLOGWARN("Each contour must have at least 3 points");
+        }
+        std::vector<double> x_cop;
+        std::vector<double> y_cop;
+        std::vector<double> z_cop;
+        for(int j = 0; j < x_cop_string.size(); j++) {
+            try {
+                x_cop.emplace_back(stod(x_cop_string[j]));
+                y_cop.emplace_back(stod(y_cop_string[j]));
+                z_cop.emplace_back(stod(z_cop_string[j]));
+                std::string error_message = "Invalid Input";
+            } catch(std::string error_message) {
+                return true;
+            }
+        }
+        x_cops.emplace_back(x_cop);
+        y_cops.emplace_back(y_cop);
+        z_cops.emplace_back(z_cop);
+    }
+
+    for(int i = 0; i < x_cops.size(); i++) {
+        contour_of_points<double> cop;
+        for(int j = 0; j < x_cops[i].size(); j++) {
+            const vec3<double> p(static_cast<double>(x_cops[i][j]),
+                                static_cast<double>(y_cops[i][j]),
+                                static_cast<double>(z_cops[i][j]));
+            cop.points.emplace_back(p);
+        }
+        cop.closed = true;
+        cop.metadata["ROILabel"] = ROILabel;
+        cc.contours.emplace_back(cop);
+    }
+
     DICOM_data.contour_data->ccs.emplace_back(cc);
     return true;
 }
 
-std::vector<double> ValueStringToDoubleList(std::string input) {
-    std::vector<double> values;
+std::vector<std::string> SplitString(std::string input, std::string delimiter) {
+    std::vector<std::string> values;
     size_t pos = 0;
-    std::string delimiter = " ";
     std::string token;
     while ((pos = input.find(delimiter)) != std::string::npos) {
         token = input.substr(0, pos);
         try {
-            values.emplace_back(stod(token));
+            values.emplace_back(token);
             std::string error_message = "Invalid Input";
         } catch(std::string error_message) {
-            YLOGWARN(error_message);
-            return std::vector<double>();
+            return std::vector<std::string>();
         }
         input.erase(0, pos + delimiter.length());
     }
+    values.emplace_back(input);
     return values;
 }
-

--- a/src/Operations/CreateCustomContour.h
+++ b/src/Operations/CreateCustomContour.h
@@ -15,4 +15,4 @@ bool CreateCustomContour(Drover &DICOM_data,
                     std::map<std::string, std::string>& /*InvocationMetadata*/,
                     const std::string& FilenameLex);
 
-std::vector<double> ValueStringToDoubleList(std::string input);
+std::vector<std::string> SplitString(std::string input, std::string delimiter);

--- a/src/Operations/CreateCustomContour.h
+++ b/src/Operations/CreateCustomContour.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <map>
+#include <list>
 #include <string>
 
 #include "../Structs.h"
@@ -14,3 +14,5 @@ bool CreateCustomContour(Drover &DICOM_data,
                     const OperationArgPkg& /*OptArgs*/,
                     std::map<std::string, std::string>& /*InvocationMetadata*/,
                     const std::string& FilenameLex);
+
+std::vector<double> ValueStringToDoubleList(std::string input);

--- a/src/Operations/CreateCustomContour.h
+++ b/src/Operations/CreateCustomContour.h
@@ -1,0 +1,16 @@
+// CreateCustomContour.h.
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "../Structs.h"
+
+
+OperationDoc OpArgDocCreateCustomContour();
+
+bool CreateCustomContour(Drover &DICOM_data,
+                    const OperationArgPkg& /*OptArgs*/,
+                    std::map<std::string, std::string>& /*InvocationMetadata*/,
+                    const std::string& FilenameLex);

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -399,8 +399,8 @@ std::vector< std::array<size_t, 3> > Tile_Contours(
 
 
     // Even for debugging, don't use this for dense graphs as it will print a lot to stdout
-    if (m < 15 && n < 15)
-        print_path(nodes, optimal_path);
+    /* if (m < 15 && n < 15) */
+    /*     print_path(nodes, optimal_path); */
 
     std::vector<std::array<size_t, 3>> ret;
 

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -646,14 +646,17 @@ Minimally_Amalgamate_Contours(
             auto a_v1_it = std::prev(std::end(amal.points));
             auto a_v2_it = std::begin(amal.points);
 
-            // Disregard this edge if any of the verts are ficticious.
-            if( is_a_pseudo_vert(a_v1_it)
-            ||  is_a_pseudo_vert(a_v2_it) ){
-                continue;
-            }
 
             const auto a_end = std::end(amal.points);
             while(a_v2_it != a_end){
+                // Disregard this edge if any of the verts are ficticious.
+                if( is_a_pseudo_vert(a_v1_it)
+                ||  is_a_pseudo_vert(a_v2_it) ){
+                    YLOGWARN("We are here again!");
+                    a_v1_it = a_v2_it;
+                    ++a_v2_it;
+                    continue;
+                }
                 auto b_v1_it = std::prev(std::end(b_it->get().points));
                 auto b_v2_it = std::begin(b_it->get().points);
                 const auto b_end = std::end(b_it->get().points);

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -364,7 +364,7 @@ std::vector< std::array<size_t, 3> > Tile_Contours(
     iter_A = std::next(iter_A);
 
     size_t m = *begin_A == contour_A.points.back() ? N_A - 1 : N_A;
-    size_t n = *begin_B == contour_B.points.back() ? N_A - 1 : N_A;
+    size_t n = *begin_B == contour_B.points.back() ? N_B - 1 : N_B;
 
     // We repeat over A twice, since to search the graph we need to search repeats
     // Don't loop over all points since last point is repeat of first

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -651,8 +651,7 @@ Minimally_Amalgamate_Contours(
             while(a_v2_it != a_end){
                 // Disregard this edge if any of the verts are ficticious.
                 if( is_a_pseudo_vert(a_v1_it)
-                ||  is_a_pseudo_vert(a_v2_it) ){
-                    YLOGWARN("We are here again!");
+                ||  is_a_pseudo_vert(a_v2_it) ){  
                     a_v1_it = a_v2_it;
                     ++a_v2_it;
                     continue;

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -745,7 +745,7 @@ Minimally_Amalgamate_Contours(
     return amal;
 }
 
-contour_of_points<double>
+/*contour_of_points<double>
 Minimally_Amalgamate_Contours_N_to_N(
         const vec3<double> &ortho_unit,
         const vec3<double> &pseudo_vert_offset,
@@ -806,4 +806,4 @@ Minimally_Amalgamate_Contours_N_to_N(
             }
         }
     }
-}
+}*/

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -16,6 +16,8 @@
 #include <cmath>
 #include <memory>
 #include <stdexcept>
+#include <limits>           //Needed for double max
+#include <queue>
 
 #include <cstdlib>            //Needed for exit() calls.
 #include <utility>            //Needed for std::pair.
@@ -34,6 +36,395 @@
 
 #include "Simple_Meshing.h"
 
+// This can be useful when debuggin with gdb to prevent <optimized out>
+// Obviously don't enable this when tiling large objects
+/* #pragma GCC push_options */
+/* #pragma GCC optimize ("O0") */
+
+/*
+ * Class to represent a single node in a vertex
+ */
+class node {
+    public:
+        // Indices of A and B that this node represents
+        size_t iA, iB;
+        // Weight of choosing the next vertex to be on A/B
+        // In our case this corresponds to the area of (iA, iB, iA+1) 
+        // or (iA, iB, iB+1) respectively
+        double wA, wB;
+
+        node(size_t ia, size_t ib, 
+                vec3<double>& point_A,
+                vec3<double>& point_B,
+                vec3<double>& point_A_next,
+                vec3<double>& point_B_next){
+            iA = ia; iB = ib;
+            const vec3<double> ab = point_A - point_B;
+            // Weights are surface area of potential next faces
+            /* wA = 0.5 * ab.Cross(point_B - point_A_next).length(); */
+            /* wB = 0.5 * ab.Cross(point_A - point_B_next).length(); */
+
+            // Perimeter
+            wA = ab.length()
+                + (point_A - point_A_next).length()
+                + (point_B - point_A_next).length();
+
+            wB = ab.length()
+                + (point_A - point_B_next).length()
+                + (point_B - point_B_next).length();
+        }
+};
+
+/*
+ * Convert top and bottom paths to not be overlapping by swapping sections
+ *
+ * path_top: top path to modify
+ * path_bottom: bottom path to modify
+ */
+void convert_nonoverlapping(
+        std::vector<size_t>& path_top, std::vector<size_t>& path_bottom){
+    for(size_t k = 0; k < path_top.size(); ++k){
+        if(path_top[k] > path_bottom[k]){
+            std::swap(path_top[k], path_bottom[k]);
+        }
+    }
+}
+
+/*
+ * Calculates lowest cost path between assuming a specific start vertex
+ *
+ * nodes: graph of nodes
+ * k: index of row to start at
+ * path_top: top bounding path to search below
+ * path_bottom: bottom bounding path to search above
+ *
+ * Assumes bottom_path[i] > top_path[i] for all i
+ *
+ * returns (minimal path, cost of minimal path)
+ */
+std::pair<std::vector<size_t>, double> 
+single_path(std::vector<std::vector<node>>& nodes, size_t k,
+        std::vector<size_t>& path_top, std::vector<size_t>& path_bottom){
+    size_t m = nodes.size()/2, n = nodes[0].size();
+
+    convert_nonoverlapping(path_top, path_bottom);
+
+    // i, j, distance
+    std::vector<std::vector<double>> distances(2*m, 
+            std::vector<double>(n, std::numeric_limits<double>::max()));
+
+    std::set<std::pair<size_t, size_t>> visited = {};
+
+    // Current minimum distance among nodes
+    typedef std::pair<double, std::pair<size_t, size_t>> node_dist;
+    std::priority_queue<node_dist, std::vector<node_dist>, std::greater<node_dist>> min_dist;
+    distances[k][0] = 0;
+    min_dist.push({0, {k, 0}});
+    
+
+    // Loop to get distances of each relevant node
+    while(!min_dist.empty() && (min_dist.top().second.first != m + k || min_dist.top().second.second != n-1)){
+        size_t i = min_dist.top().second.first;
+        size_t j = min_dist.top().second.second;
+        min_dist.pop();
+        if(i == m+k && j == n-1) break;
+
+        // Bottom of the current path
+        // Since we only directly get the top, have to compute this
+        size_t bottom = j == n-1 ? m+k : path_bottom[j+1];
+        // Traverse next nodes and set their distances based on current
+        // Try down
+        // k instead of n because we can't go past endpoint
+        if(i+1 <= m + k && i+1 >= path_top[j] && i+1 <= bottom && !visited.count({i+1, j})){
+            distances[i+1][j] = std::min(distances[i][j] + nodes[i][j].wA, distances[i+1][j]);
+            min_dist.push({distances[i+1][j], {i+1, j}});
+            visited.insert({i+1, j});
+        }
+        // Try right
+        if(j+1 < n && i >= path_top[j+1] && i <= bottom && !visited.count({i, j+1})){
+            distances[i][j+1] = std::min(distances[i][j] + nodes[i][j].wB, distances[i][j+1]);
+            min_dist.push({distances[i][j+1], {i, j+1}});
+            visited.insert({i, j+1});
+        }
+    }
+
+    // Reconstruct best path
+    std::vector<size_t> ret(n);
+    ret[0] = k;
+
+    for(size_t j = n-1, i = m + k; j > 0; --j){
+        while(i > 0 && j > 0 && distances[i-1][j] + nodes[i-1][j].wA <= distances[i][j-1] + nodes[i][j-1].wB) --i;
+        ret[j] = i;
+    }
+    // Cost of path is length to end node
+    return {ret, distances[m + k][n-1]};
+}
+
+/*
+ * Calculates optimal path between two indices
+ *
+ * nodes: graph of nodes
+ * i: Upper index
+ * j: lower index, assumes i<j
+ * path_i: minimum path starting from i
+ * path_j: minimum path starting from j
+ *
+ * returns (minimal path, cost of minimal path)
+ */
+std::pair<std::vector<size_t>, double> 
+paths_between(std::vector<std::vector<node>>& nodes, size_t i, size_t j, 
+        std::vector<size_t>& path_i, std::vector<size_t>& path_j){
+    // If we're at something of length 2 or less, stop recursion
+    if(j-i < 2) return {std::vector<size_t>(), std::numeric_limits<double>::max()};
+    size_t k = (i + j) / 2;
+    
+    // SINGLEPATH(k, G'(i, j))
+    auto [path_k, cost_k] = single_path(nodes, k, path_i, path_j);
+
+    // PATHSBETWEEN(i, k)
+    // PATHSBETWEEN(k, j)
+    auto [path_before, cost_before] = paths_between(nodes, i, k, path_i, path_k);
+    auto [path_after, cost_after] = paths_between(nodes, k, j, path_k, path_j);
+
+    // Return minimum of paths calculated
+    if(cost_before < cost_k && cost_before < cost_after){
+        return {path_before, cost_before};
+    }
+    else if(cost_after < cost_k && cost_after < cost_before){
+        return {path_after, cost_after};
+    }
+    else {
+        return {path_k, cost_k};
+    }
+}
+
+/*
+ * Calculates optimal path through graph representation of tiling
+ *
+ * nodes: graph of nodes, size 2m x n
+ *
+ * Returns minimal path
+ */
+std::vector<size_t> all_paths(std::vector<std::vector<node>>& nodes){
+    // Start with G' as best bounds
+    std::vector<size_t> top_path(nodes[0].size(), 0);
+    std::vector<size_t> bottom_path(nodes[0].size(), nodes.size());
+    
+    // nodes.size() should always be even
+    // There's some weirdness with the indexing relative to the paper since
+    // they label their vertices for 0,1,...,m, so have m+1 vertices
+    size_t m = nodes.size()/2;
+
+    // SINGLEPATH(0,G')
+    // SINGLEPATH(m,G')
+    auto [path_start, cost_start] = single_path(nodes, 0, top_path, bottom_path);
+    auto [path_end, cost_end] = single_path(nodes, m-1, top_path, bottom_path);
+
+    // PATHSBETWEEN(0, m)
+    auto [path_between, cost_between] = paths_between(nodes, 0, m-1, path_start, path_end);
+
+    // Return minimum of paths calculated
+    if(cost_start < cost_end && cost_start < cost_between){
+        return path_start;
+    }
+    else if(cost_end < cost_start && cost_end < cost_between){
+        return path_end;
+    }
+    else {
+        return path_between;
+    }
+}
+
+/*
+ * Quick and dirty way of visualizing graphs with a colored path, this is purely for
+ * debugging and definitey isn't the most elegantly written, but the output looks pretty
+ */
+void print_path(std::vector<std::vector<node>> nodes, std::vector<size_t> path){
+    printf("Path: ");
+    for(size_t p : path){
+        printf("%zu  ", p);
+    }
+    printf("\n");
+
+    path.push_back(path[0] + nodes.size()/2);
+    const char* white = "\033[0;37m";
+    const char* green = "\033[0;32m";
+    
+    for(size_t i = 0; i < nodes.size(); ++i){
+        for(size_t j = 0; j < nodes[0].size(); ++j){
+            const char* c_node;
+            if(i >= path[j] && i <= path[j+1]){
+                c_node = green;
+            } else c_node = white;
+            const char* c_edge;
+            if(i >= path[j] && i == path[j+1] && j < nodes[0].size()-1){
+                c_edge = green;
+            } else c_edge = white;
+            printf("-- %so%s --%-6.2lf%s", c_node, c_edge, nodes[i][j].wB, white);
+        }
+        printf("\n");
+        for(size_t j = 0; j < nodes[0].size(); ++j){
+            const char* c;
+            if(i >= path[j] && i < path[j+1] && path[j] != path[j+1]){
+                c = green;
+            } else c = white;
+            printf("   %s|%s         ", c, white);
+        }
+        printf("\n");
+        for(size_t j = 0; j < nodes[0].size(); ++j){
+            const char* c;
+            if(i >= path[j] && i < path[j+1] && path[j] != path[j+1]){
+                c = green;
+            } else c = white;
+            printf("   %s%-6.2lf%s    ", c, nodes[i][j].wA, white);
+        }
+        printf("\n");
+        for(size_t j = 0; j < nodes[0].size(); ++j){
+            const char* c;
+            if(i >= path[j] && i < path[j+1] && path[j] != path[j+1]){
+                c = green;
+            } else c = white;
+            printf("   %s|%s         ", c, white);
+        }
+        printf("\n");
+    }
+}
+
+// Method taken from here: 
+// https://www.cs.jhu.edu/~misha/Fall13b/Papers/Fuchs77.pdf
+std::vector< std::array<size_t, 3> > Tile_Contours(
+        std::reference_wrapper<contour_of_points<double>> A,
+        std::reference_wrapper<contour_of_points<double>> B ){
+
+    contour_of_points<double> contour_A = A.get();
+    contour_of_points<double> contour_B = B.get();
+
+    const auto N_A = contour_A.points.size();
+    const auto N_B = contour_B.points.size();
+    if( N_A == 0 ){
+        throw std::invalid_argument("Contour A contains no vertices. Cannot continue.");
+    }
+    if( N_B == 0 ){
+        throw std::invalid_argument("Contour B contains no vertices. Cannot continue.");
+    }
+
+    // Determine contour orientations. Single-vertex contours can take any orientation, so use a reasonable default.
+    auto ortho_unit_A = vec3<double>(0.0, 0.0, 1.0);
+    auto ortho_unit_B = vec3<double>(0.0, 0.0, 1.0);
+    try{
+        ortho_unit_A = contour_A.Estimate_Planar_Normal();
+    }catch(const std::exception &){}
+    try{
+        ortho_unit_B = contour_B.Estimate_Planar_Normal();
+    }catch(const std::exception &){}
+
+    // Ensure the contours have the same orientation.
+    if(ortho_unit_A.Dot(ortho_unit_B) <= 0.0){
+        // Handle special cases
+        if( (N_A == 1) && (N_B != 1) ){
+            ortho_unit_A = ortho_unit_B;
+        }else if( (N_A != 1) && (N_B == 1) ){
+            ortho_unit_B = ortho_unit_A;
+
+        // Otherwise, flip one of the contours, recurse, and adjust the face labels to point to the actual vertex
+        // layout.
+        //
+        // Note: This effectively ignores contour orientation altogether.
+        }else{
+            YLOGWARN("Ignoring adjacent contours with opposite orientations. Recursing..");
+            std::reverse( std::begin(contour_B.points), std::end(contour_B.points) );
+            auto faces = Tile_Contours(A, std::ref(contour_B) );
+
+            for(auto &face_arr: faces){
+                for(auto &v_i : face_arr){
+                    if(N_A <= v_i) v_i = N_A + (N_B - 1) - (v_i - N_A);
+                }
+            }
+            return faces;
+        }
+    }
+
+    /***************************************************************************
+     * Graph theory search
+     **************************************************************************/
+
+    std::vector<std::vector<node>> nodes;
+
+
+    // Keep track of where we are looping over points
+    auto iter_A = std::begin(contour_A.points);
+
+    // const convenience iterators
+    const auto begin_A = std::begin(contour_A.points);
+    const auto begin_B = std::begin(contour_B.points);
+    const auto end_A = std::end(contour_A.points);
+    const auto end_B = std::end(contour_B.points);
+
+    auto p_i_next = *iter_A;
+    iter_A = std::next(iter_A);
+
+    size_t m = *begin_A == contour_A.points.back() ? N_A - 1 : N_A;
+    size_t n = *begin_B == contour_B.points.back() ? N_A - 1 : N_A;
+
+    // We repeat over A twice, since to search the graph we need to search repeats
+    // Don't loop over all points since last point is repeat of first
+    for(size_t i = 0; i < 2 * m; ++i, ++iter_A){
+
+        auto p_i = p_i_next;
+        // If at end of iterator loop back to beginning
+        if(std::next(iter_A) == end_A) iter_A = begin_A;
+        p_i_next = *iter_A;
+
+        nodes.push_back(std::vector<node>());
+
+        auto iter_B = std::begin(contour_B.points);
+        auto p_j_next = *iter_B;
+        iter_B = std::next(iter_B);
+        for(size_t j = 0; j < n; ++j, ++iter_B){
+
+            auto p_j = p_j_next;
+            // If at end of iterator loop back to beginning
+            p_j_next = iter_B == end_B ? *begin_B : *iter_B;
+
+            nodes[i].push_back(node(i % m, j, p_i, p_j, p_i_next, p_j_next));
+        }
+        nodes[i].push_back(node(i % m, 0, p_i, *begin_B, p_i_next, *std::next(begin_B)));
+    }
+
+    // Useful to check progress of tiling if its going too slow
+    printf("Finding Optimal path, m=%zu, n=%zu\n", m, n);
+
+    // Execute shortest path graph search
+    std::vector<size_t> optimal_path = all_paths(nodes);
+
+
+    // Even for debugging, don't use this for dense graphs as it will print a lot to stdout
+    if (m < 15 && n < 15)
+        print_path(nodes, optimal_path);
+
+    std::vector<std::array<size_t, 3>> ret;
+
+    // Reconstruct paths
+    for(size_t j = 0; j <= n; ++j){
+        size_t end_i = (j == n ? optimal_path[0] + m : optimal_path[j+1]);
+        for(size_t i = optimal_path[j]; i <= end_i; ++i){
+            // If end then the next node is to the right, otherwise down
+            // On last column we can't go right any more so skip
+            size_t next_index;
+
+            if(i < end_i) next_index = nodes[i+1][j].iA;
+            else if(j == n) continue;
+            else next_index = nodes[i][j+1].iB + N_A;
+
+            ret.push_back({nodes[i][j].iA, nodes[i][j].iB + N_A, next_index});
+        }
+    }
+    
+    return ret;
+    
+}
+
+/* #pragma GCC pop_options */
 
 // Low-level routine that joins the vertices of two contours.
 // Returns a list of faces where the vertex indices refer to A followed by B.

--- a/src/Simple_Meshing.h
+++ b/src/Simple_Meshing.h
@@ -20,6 +20,10 @@
 #include <algorithm>
 #include <optional>
 
+std::vector< std::array<size_t, 3> > Tile_Contours(
+        std::reference_wrapper<contour_of_points<double>> A,
+        std::reference_wrapper<contour_of_points<double>> B );
+
 // Low-level routine that joins the vertices of two contours.
 // Returns a list of faces where the vertex indices refer to A followed by B.
 std::vector< std::array<size_t, 3> >


### PR DESCRIPTION
This is the PR for the work done by capstone group 2300. The project goal was to implement algorithms to convert contours into surface meshes. A brief summary of the changes made is as follows:
- Added operation to create custom contours
- Added operation to compare meshes (with metrics such as hausdorff distance, surface area, volume, manifoldness etc.)
- Made changes to allow meshing of nested contours and capping for pipe like structures
- Implemented specialized algorithm for 2-to-1 branching
- Implemented Fuchs algorithm for ideal tiling