### PR TITLE
Expose sketch mesh Boolean engine selection

### DIFF
--- a/src/Operations/SDL_Viewer.cc
+++ b/src/Operations/SDL_Viewer.cc
@@ -8678,6 +8678,17 @@ bool SDL_Viewer(Drover &DICOM_data,
                     if(ImGui::Combo("Procedure", &proc_idx, proc_items, 6)){
                         active.procedure.kind = static_cast<sketch_procedure_kind_t>(proc_idx);
                     }
+                    int boolean_engine_idx = static_cast<int>(active.procedure.boolean_engine);
+                    const char *boolean_engine_items[] = {
+                        "YgorMeshesBoolean",
+                        "YgorMeshesBoolean2",
+                        "YgorMeshesBoolean3",
+                        "YgorMeshesBoolean4"
+                    };
+                    if(ImGui::Combo("Boolean engine", &boolean_engine_idx, boolean_engine_items, 4)){
+                        active.procedure.boolean_engine = static_cast<sketch_boolean_engine_t>(boolean_engine_idx);
+                    }
+                    ImGui::TextWrapped("Used by extend and carve procedures. The selected engine is used directly; failures are reported without trying another engine.");
                 }
 
                 // Extrusion parameters.

--- a/src/Sketch_Mesh_Builder.cc
+++ b/src/Sketch_Mesh_Builder.cc
@@ -12,8 +12,10 @@
 
 #include <YgorLog.h>
 #include <YgorMathIOOBJ.h>
-//#include <YgorMeshesBoolean.h>
+#include <YgorMeshesBoolean.h>
 #include <YgorMeshesBoolean2.h>
+#include <YgorMeshesBoolean3.h>
+#include <YgorMeshesBoolean4.h>
 
 namespace {
 
@@ -48,16 +50,36 @@ build_extruded_mesh(const Sketch &sketch,
 
 fv_surface_mesh<double, uint64_t>
 boolean_union_meshes(const fv_surface_mesh<double, uint64_t> &parent_mesh,
-                     const fv_surface_mesh<double, uint64_t> &child_mesh){
-//    return BooleanUnion(parent_mesh, child_mesh, /*max_depth=*/5, /*boundary_scale=*/0.0);
-    return BooleanUnion2(parent_mesh, child_mesh, /*snap_eps=*/0.0);
+                     const fv_surface_mesh<double, uint64_t> &child_mesh,
+                     sketch_boolean_engine_t engine){
+    switch(engine){
+        case sketch_boolean_engine_t::ygor_1:
+            return BooleanUnion(parent_mesh, child_mesh, /*max_depth=*/5, /*boundary_scale=*/0.0);
+        case sketch_boolean_engine_t::ygor_2:
+            return BooleanUnion2(parent_mesh, child_mesh, /*snap_eps=*/0.0);
+        case sketch_boolean_engine_t::ygor_3:
+            return BooleanUnion3(parent_mesh, child_mesh);
+        case sketch_boolean_engine_t::ygor_4:
+            return BooleanUnion4(parent_mesh, child_mesh);
+    }
+    throw std::invalid_argument("Unknown sketch Boolean engine");
 }
 
 fv_surface_mesh<double, uint64_t>
 boolean_subtract_meshes(const fv_surface_mesh<double, uint64_t> &parent_mesh,
-                        const fv_surface_mesh<double, uint64_t> &child_mesh){
-//    return BooleanSubtraction(parent_mesh, child_mesh, /*max_depth=*/5, /*boundary_scale=*/0.0);
-    return BooleanSubtraction2(parent_mesh, child_mesh, /*snap_eps=*/0.0);
+                        const fv_surface_mesh<double, uint64_t> &child_mesh,
+                        sketch_boolean_engine_t engine){
+    switch(engine){
+        case sketch_boolean_engine_t::ygor_1:
+            return BooleanSubtraction(parent_mesh, child_mesh, /*max_depth=*/5, /*boundary_scale=*/0.0);
+        case sketch_boolean_engine_t::ygor_2:
+            return BooleanSubtraction2(parent_mesh, child_mesh, /*snap_eps=*/0.0);
+        case sketch_boolean_engine_t::ygor_3:
+            return BooleanSubtraction3(parent_mesh, child_mesh);
+        case sketch_boolean_engine_t::ygor_4:
+            return BooleanSubtraction4(parent_mesh, child_mesh);
+    }
+    throw std::invalid_argument("Unknown sketch Boolean engine");
 }
 
 template <class BooleanOp>
@@ -67,6 +89,7 @@ compute_boolean_procedure(const char *procedure_name,
                           const std::optional<fv_surface_mesh<double, uint64_t>> &parent_mesh,
                           const Sketch &sketch,
                           const Sketch::extrusion_options_t &options,
+                          sketch_boolean_engine_t boolean_engine,
                           fv_surface_mesh<double, uint64_t> &result_mesh,
                           std::string *error_message,
                           BooleanOp &&boolean_op){
@@ -85,7 +108,7 @@ compute_boolean_procedure(const char *procedure_name,
     }
 
     try{
-        result_mesh = boolean_op(parent_mesh.value(), extruded_mesh);
+        result_mesh = boolean_op(parent_mesh.value(), extruded_mesh, boolean_engine);
         return true;
     }catch(const std::exception &e){
         YLOGWARN("Sketch mesh builder '" << procedure_name
@@ -115,8 +138,7 @@ compute_boolean_procedure(const char *procedure_name,
         }
     }catch(...){}
 
-    result_mesh = make_empty_mesh();
-    return true;
+    return false;
 }
 
 } // namespace
@@ -146,6 +168,24 @@ bool string_to_sketch_procedure_kind(const std::string &s, sketch_procedure_kind
     return false;
 }
 
+std::string sketch_boolean_engine_to_string(sketch_boolean_engine_t engine){
+    switch(engine){
+        case sketch_boolean_engine_t::ygor_1: return "ygor_1";
+        case sketch_boolean_engine_t::ygor_2: return "ygor_2";
+        case sketch_boolean_engine_t::ygor_3: return "ygor_3";
+        case sketch_boolean_engine_t::ygor_4: return "ygor_4";
+    }
+    return "ygor_2";
+}
+
+bool string_to_sketch_boolean_engine(const std::string &s, sketch_boolean_engine_t &out){
+    if(s == "ygor_1" || s == "YgorMeshesBoolean"){  out = sketch_boolean_engine_t::ygor_1; return true; }
+    if(s == "ygor_2" || s == "YgorMeshesBoolean2"){ out = sketch_boolean_engine_t::ygor_2; return true; }
+    if(s == "ygor_3" || s == "YgorMeshesBoolean3"){ out = sketch_boolean_engine_t::ygor_3; return true; }
+    if(s == "ygor_4" || s == "YgorMeshesBoolean4"){ out = sketch_boolean_engine_t::ygor_4; return true; }
+    return false;
+}
+
 // ---------------------------------------------------------------------------
 // Sketch_Procedure I/O.
 // ---------------------------------------------------------------------------
@@ -155,6 +195,7 @@ bool Sketch_Procedure::write_to(std::ostream &os) const {
 
     os << "procedure_begin\n";
     os << "procedure_kind " << sketch_procedure_kind_to_string(kind) << "\n";
+    os << "boolean_engine " << sketch_boolean_engine_to_string(boolean_engine) << "\n";
     os << "extrusion_into_frame_length " << extrusion_options.into_frame_length << "\n";
     os << "extrusion_out_of_frame_length " << extrusion_options.out_of_frame_length << "\n";
     os << "extrusion_into_frame_angle_degrees " << extrusion_options.into_frame_angle_degrees << "\n";
@@ -182,6 +223,11 @@ bool Sketch_Procedure::read_from(std::istream &is, Sketch_Procedure &out){
         }else if(keyword == "procedure_kind"){
             std::string kind_str;
             if(!(iss >> kind_str) || !string_to_sketch_procedure_kind(kind_str, out.kind)){
+                return false;
+            }
+        }else if(keyword == "boolean_engine"){
+            std::string engine_str;
+            if(!(iss >> engine_str) || !string_to_sketch_boolean_engine(engine_str, out.boolean_engine)){
                 return false;
             }
         }else if(keyword == "extrusion_into_frame_length"){
@@ -367,6 +413,7 @@ bool Sketch_Mesh_Builder::compute_node(std::size_t idx, std::string *error_messa
                                           parent_mesh,
                                           current.sketch,
                                           current.procedure.extrusion_options,
+                                          current.procedure.boolean_engine,
                                           mesh,
                                           error_message,
                                           boolean_union_meshes)){
@@ -383,6 +430,7 @@ bool Sketch_Mesh_Builder::compute_node(std::size_t idx, std::string *error_messa
                                           parent_mesh,
                                           current.sketch,
                                           current.procedure.extrusion_options,
+                                          current.procedure.boolean_engine,
                                           mesh,
                                           error_message,
                                           boolean_subtract_meshes)){

--- a/src/Sketch_Mesh_Builder.h
+++ b/src/Sketch_Mesh_Builder.h
@@ -28,10 +28,24 @@ enum class sketch_procedure_kind_t {
 std::string sketch_procedure_kind_to_string(sketch_procedure_kind_t kind);
 bool string_to_sketch_procedure_kind(const std::string &s, sketch_procedure_kind_t &out);
 
+// Supported Ygor b-rep mesh Boolean engines.
+enum class sketch_boolean_engine_t {
+    ygor_1,
+    ygor_2,
+    ygor_3,
+    ygor_4,
+};
+
+std::string sketch_boolean_engine_to_string(sketch_boolean_engine_t engine);
+bool string_to_sketch_boolean_engine(const std::string &s, sketch_boolean_engine_t &out);
+
 // Holds all information needed to apply a procedure that combines
 // a parent mesh with a sketch to produce a child mesh.
 struct Sketch_Procedure {
     sketch_procedure_kind_t kind = sketch_procedure_kind_t::clear;
+
+    // Boolean engine used when kind == extend or carve.
+    sketch_boolean_engine_t boolean_engine = sketch_boolean_engine_t::ygor_2;
 
     // Extrusion parameters (used when kind == extrusion or through_hole).
     Sketch::extrusion_options_t extrusion_options;

--- a/src/Sketch_Mesh_Builder_Tests.cc
+++ b/src/Sketch_Mesh_Builder_Tests.cc
@@ -68,6 +68,7 @@ static Sketch make_sparse_circle_sketch(){
 TEST_CASE("Sketch_Procedure write/read round-trip"){
     Sketch_Procedure proc;
     proc.kind = sketch_procedure_kind_t::extrusion;
+    proc.boolean_engine = sketch_boolean_engine_t::ygor_4;
     proc.extrusion_options.into_frame_length = 7.5;
     proc.extrusion_options.out_of_frame_length = 3.25;
     proc.extrusion_options.into_frame_angle_degrees = 1.0;
@@ -81,12 +82,32 @@ TEST_CASE("Sketch_Procedure write/read round-trip"){
     Sketch_Procedure loaded;
     REQUIRE(Sketch_Procedure::read_from(ss, loaded));
     CHECK(loaded.kind == sketch_procedure_kind_t::extrusion);
+    CHECK(loaded.boolean_engine == sketch_boolean_engine_t::ygor_4);
     CHECK(loaded.extrusion_options.into_frame_length == doctest::Approx(7.5));
     CHECK(loaded.extrusion_options.out_of_frame_length == doctest::Approx(3.25));
     CHECK(loaded.extrusion_options.into_frame_angle_degrees == doctest::Approx(1.0));
     CHECK(loaded.extrusion_options.out_of_frame_angle_degrees == doctest::Approx(-2.0));
     CHECK(loaded.extrusion_options.curve_segments == 32U);
     CHECK(loaded.extrusion_options.max_discretization_error == doctest::Approx(0.05));
+}
+
+TEST_CASE("Sketch_Procedure Boolean engine string conversion"){
+    for(auto engine : { sketch_boolean_engine_t::ygor_1,
+                        sketch_boolean_engine_t::ygor_2,
+                        sketch_boolean_engine_t::ygor_3,
+                        sketch_boolean_engine_t::ygor_4 }){
+        const auto s = sketch_boolean_engine_to_string(engine);
+        sketch_boolean_engine_t out = sketch_boolean_engine_t::ygor_2;
+        REQUIRE(string_to_sketch_boolean_engine(s, out));
+        CHECK(out == engine);
+    }
+
+    sketch_boolean_engine_t legacy = sketch_boolean_engine_t::ygor_2;
+    REQUIRE(string_to_sketch_boolean_engine("YgorMeshesBoolean3", legacy));
+    CHECK(legacy == sketch_boolean_engine_t::ygor_3);
+
+    sketch_boolean_engine_t dummy;
+    CHECK_FALSE(string_to_sketch_boolean_engine("invalid_boolean_engine", dummy));
 }
 
 TEST_CASE("Sketch_Procedure kind string conversion"){
@@ -245,6 +266,7 @@ TEST_CASE("Sketch_Mesh_Builder write/read round-trip with sketches"){
     builder.append_default_node();
     builder.node(1).sketch = make_circle_sketch(5.0, 5.0, 3.0);
     builder.node(1).procedure.kind = sketch_procedure_kind_t::through_hole;
+    builder.node(1).procedure.boolean_engine = sketch_boolean_engine_t::ygor_3;
     builder.set_active_node_index(1U);
 
     std::stringstream ss;
@@ -257,6 +279,7 @@ TEST_CASE("Sketch_Mesh_Builder write/read round-trip with sketches"){
     CHECK(loaded.node(0).procedure.kind == sketch_procedure_kind_t::extrusion);
     CHECK(loaded.node(0).procedure.extrusion_options.into_frame_length == doctest::Approx(5.0));
     CHECK(loaded.node(1).procedure.kind == sketch_procedure_kind_t::through_hole);
+    CHECK(loaded.node(1).procedure.boolean_engine == sketch_boolean_engine_t::ygor_3);
     // Verify sketch data survived.
     CHECK(loaded.node(0).sketch.has_plane());
     CHECK(loaded.node(1).sketch.has_plane());


### PR DESCRIPTION
### Motivation
- Provide an explicit per-procedure choice of Ygor b-rep Boolean engine so users can pick which `YgorMeshesBoolean{,2,3,4}` implementation to use for `extend` and `carve` operations.
- Ensure the selected engine is used deterministically and that failures are reported rather than silently falling back to other engines or returning an empty mesh.

### Description
- Added `enum class sketch_boolean_engine_t { ygor_1, ygor_2, ygor_3, ygor_4 }` and conversion/IO helpers `sketch_boolean_engine_to_string` and `string_to_sketch_boolean_engine` and persisted the choice on `Sketch_Procedure` via a `boolean_engine` member (default `ygor_2`).
- Wired the new engine selection into boolean dispatch: `extend` and `carve` now call a single chosen engine (`BooleanUnion/Union2/Union3/Union4` and `BooleanSubtraction/Subtraction2/Subtraction3/Subtraction4`) through `compute_boolean_procedure` and do not try other engines on failure.
- Exposed a UI control in the sketch extrusion panel (`SDL_Viewer`) as a combo box labeled `Boolean engine` with items `YgorMeshesBoolean`, `YgorMeshesBoolean2`, `YgorMeshesBoolean3`, and `YgorMeshesBoolean4` and an explanatory tooltip-like text noting no retry/fallback behavior.
- Updated serialization to include `boolean_engine` in `Sketch_Procedure::write_to` / `read_from` and added unit tests covering boolean-engine string conversions and I/O round trips.
- On unknown engine cases the code now throws/returns an error path rather than silently returning an empty mesh.

Changed files: `src/Sketch_Mesh_Builder.h`, `src/Sketch_Mesh_Builder.cc`, `src/Operations/SDL_Viewer.cc`, `src/Sketch_Mesh_Builder_Tests.cc`.

### Testing
- Ran `git diff --check` with no whitespace issues (success).
- Attempted CMake configure: `cmake -S . -B /tmp/dcma-build -DCMAKE_BUILD_TYPE=Debug -DWITH_SDL=ON` failed because Ygor was not available in the environment (expected external dependency).
- Attempted CMake with FetchContent fallback: `cmake -S . -B /tmp/dcma-build -DCMAKE_BUILD_TYPE=Debug -DWITH_SDL=ON -DWITH_FETCHCONTENT_FALLBACK=ON` fetched Ygor but configure failed due to missing Boost headers in this build environment (dependency provisioning issue).
- Performed compile-time syntax checks: `g++ -std=c++17 -fsyntax-only -Isrc -I/tmp/Ygor/src -I/tmp/ygor-empty src/Sketch_Mesh_Builder.cc` and the same for the updated test file succeeded (syntax-only checks passed).
- Added/updated unit tests in `src/Sketch_Mesh_Builder_Tests.cc` for engine string conversion and I/O round-trip (tests included but full test run not executed here due to missing third-party build dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a338291c0088320a8212978389746b6)