### PR TITLE
Fix SDL viewer GLSL compatibility and add fallback shaders

### DIFF
--- a/src/GLSL_Shaders.cc
+++ b/src/GLSL_Shaders.cc
@@ -11,7 +11,14 @@ std::vector<glsl_shader_preset> get_glsl_shader_presets(){
 
     static const std::string invalid_hover_index =
         std::to_string(std::numeric_limits<uint32_t>::max()) + "u";
+
+    // gl_PrimitiveID is not a fragment-shader built-in in GLSL 1.40. It became
+    // available to fragment shaders with GLSL 1.50 / OpenGL 3.2. Keep the
+    // primitive-index hover path on capable implementations, and compile a
+    // no-op hover path on older GLSL implementations so the core viewer still
+    // has baseline mesh rendering.
     const std::string hover_fragment_helpers =
+        "#if __VERSION__ >= 150\n"
         "uniform uint hovered_face_index;\n"
         "uniform uint hovered_edge_index;\n"
         "uniform usamplerBuffer primitive_face_indices;\n"
@@ -51,6 +58,15 @@ vec4 apply_hover_highlight(vec4 base_colour,
     vec3 shaded = mix(base_colour.rgb * 0.65, vec3(1.0, 0.95, 0.35), 0.45 + 0.55 * diff);
     return vec4(shaded, max(base_colour.a, 0.75));
 }
+#else
+vec4 apply_hover_highlight(vec4 base_colour,
+                           vec3 frag_pos_value,
+                           vec3 frag_norm_value,
+                           vec3 flat_norm_value,
+                           bool use_smoothing_value){
+    return base_colour;
+}
+#endif
 )";
     const auto with_hover_support = [&hover_fragment_helpers](const char *fragment_shader) -> std::string {
         return hover_fragment_helpers + fragment_shader;
@@ -396,6 +412,95 @@ void main(){
     frag_colour = apply_hover_highlight(base_colour, frag_pos, frag_norm, flat_norm, use_smoothing);
 }
 )")
+    });
+
+    // ------------------------------- 9. Baseline Diffuse (fallback) ---------------------------------------
+    // Deliberately avoids primitive IDs, buffer samplers, flat interpolation, derivatives, and other
+    // optional/high-version features. The preprocessor branches also make this source usable from
+    // GLSL 1.20 compatibility contexts through current desktop GLSL implementations.
+    presets.push_back({
+        "Baseline Diffuse",
+        "Portable fallback with simple diffuse lighting and no primitive-hover support.",
+
+        R"(
+#if __VERSION__ >= 130
+in vec3 v_pos;
+in vec3 v_norm;
+out vec3 fallback_norm;
+#else
+attribute vec3 v_pos;
+attribute vec3 v_norm;
+varying vec3 fallback_norm;
+#endif
+
+uniform mat4 mvp_matrix;
+uniform mat3 norm_matrix;
+
+void main(){
+    gl_Position = mvp_matrix * vec4(v_pos, 1.0);
+    fallback_norm = normalize(norm_matrix * v_norm);
+}
+)",
+
+        R"(
+#if __VERSION__ >= 130
+in vec3 fallback_norm;
+out vec4 frag_colour;
+#define DCMA_FRAGMENT_COLOUR frag_colour
+#else
+varying vec3 fallback_norm;
+#define DCMA_FRAGMENT_COLOUR gl_FragColor
+#endif
+
+uniform vec4 user_colour;
+uniform bool use_lighting;
+
+void main(){
+    vec4 base_colour = user_colour;
+    if(use_lighting){
+        vec3 N = normalize(fallback_norm);
+        vec3 L = normalize(vec3(0.4, 0.7, 1.0));
+        float diffuse = max(dot(N, L), 0.0);
+        base_colour = vec4(user_colour.rgb * (0.25 + 0.75 * diffuse), user_colour.a);
+    }
+    DCMA_FRAGMENT_COLOUR = base_colour;
+}
+)"
+    });
+
+    // -------------------------------- 10. Baseline Unlit (fallback) ---------------------------------------
+    presets.push_back({
+        "Baseline Unlit",
+        "Minimal portable fallback that applies the model-view-projection transform and a uniform colour only.",
+
+        R"(
+#if __VERSION__ >= 130
+in vec3 v_pos;
+#else
+attribute vec3 v_pos;
+#endif
+
+uniform mat4 mvp_matrix;
+
+void main(){
+    gl_Position = mvp_matrix * vec4(v_pos, 1.0);
+}
+)",
+
+        R"(
+#if __VERSION__ >= 130
+out vec4 frag_colour;
+#define DCMA_FRAGMENT_COLOUR frag_colour
+#else
+#define DCMA_FRAGMENT_COLOUR gl_FragColor
+#endif
+
+uniform vec4 user_colour;
+
+void main(){
+    DCMA_FRAGMENT_COLOUR = user_colour;
+}
+)"
     });
 
     return presets;


### PR DESCRIPTION
## Summary

Fix SDL_Viewer shader compilation on OpenGL 3.1 / GLSL 1.40 implementations and add conservative baseline shader presets for lower-feature environments.

## Root cause

SDL_Viewer requests an OpenGL 3.1 forward-compatible core context and prepends the detected shading-language version to every shader preset. On a context reporting GLSL 1.40, the generated fragment shaders therefore use `#version 140`.

The shared hover helper nevertheless referenced `gl_PrimitiveID`. `gl_PrimitiveID` is not a fragment-shader built-in in GLSL 1.40; it is available to fragment shaders starting with GLSL 1.50 / OpenGL 3.2. A conforming GLSL 1.40 compiler can therefore reject every preset before the viewer starts.

## Changes

- Gate primitive-ID/buffer-texture hover highlighting behind `__VERSION__ >= 150`.
- Provide a no-op hover helper for older GLSL versions so all existing shading presets retain their baseline rendering under GLSL 1.40.
- Preserve full face/edge hover highlighting on GLSL 1.50+ implementations.
- Add `Baseline Diffuse`, a low-feature lighting fallback without primitive IDs, buffer samplers, flat interpolation, or derivatives.
- Add `Baseline Unlit`, a minimal transform + uniform-colour fallback.
- Make both baseline fallbacks adapt their vertex/fragment I/O syntax for GLSL 1.20 compatibility versus GLSL 1.30+.

## Validation

- Compiled `GLSL_Shaders.cc` with C++17 and warnings enabled (`-Wall -Wextra -pedantic`).
- Materialized every generated preset and preprocessed the fragment sources with `__VERSION__=140`; the GLSL 1.40 paths contain no `gl_PrimitiveID`, `usamplerBuffer`, or primitive-index buffer references.
- Checked generated shader sizes after adding a `#version 140` line; the largest is 2968 bytes, below SDL_Viewer's 4096-byte source buffers.
- Verified the branch is one commit ahead of `master` and changes only `src/GLSL_Shaders.cc`.

## Compatibility behavior

- GLSL 1.50+: existing presets retain primitive face/edge hover highlighting.
- GLSL 1.30/1.40: existing presets render normally, with shader-based primitive hover highlighting disabled.
- Baseline fallback presets avoid the higher-version features and include GLSL 1.20-compatible I/O branches for compatibility contexts.

This directly addresses the reported Windows configuration reporting OpenGL `3.1.0 NVIDIA 552.23` with GLSL 1.40.